### PR TITLE
Remove devise and add support for REST User actions

### DIFF
--- a/app/assets/javascripts/users.js.coffee
+++ b/app/assets/javascripts/users.js.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/users.css.scss
+++ b/app/assets/stylesheets/users.css.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the Users controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,5 @@
 class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
-  protect_from_forgery with: :exception
+  protect_from_forgery with: :null_session
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,114 @@
+class UsersController < ApplicationController
+  skip_before_action :verify_authenticity_token
+  
+  def index
+    q = User
+    if !params.blank?
+      search_params.each do |key, val|
+        q = q.where(key => val)
+      end
+      if q.count == 0
+        render :json => q.all, :status => 404
+        return
+      end
+    end
+    render :json => q.all
+  end
+  
+  def show
+    id = params[:id]
+    uid = params[:uid]
+    user = nil
+    if id.blank? || id.to_i <= 0
+      render :json => nil, :status => 422
+    elsif User.exists?(id) && user = User.find(id)
+      render :json => user
+    else
+      render :json => {}, :status => 404
+    end
+  end
+
+  def create
+    Rails.logger.debug "Creating!"
+    begin
+      u = User.create(create_params)
+    rescue ActiveRecord::RecordNotUnique => e
+      u && u.errors.add(:base, 'Dupliate record')
+    end
+    
+    if u && u.errors.blank?
+      u.update_attribute :encrypted_password, params[:encrypted_password] if params[:encrypted_password]
+      u.update_attribute :confirmation_token, params[:confirmation_token] if params[:confirmation_token]
+      render :json => u
+    else
+      Rails.logger.debug "Errors: #{u && u.errors.inspect}"
+      render :json => {}, :status => 422
+    end
+  end
+
+  def update
+    Rails.logger.debug "Updating!"
+    id = params[:id]
+    uid = params[:uid]
+    u = nil
+    if (id && User.exists?(id) && u = User.find(id)) || (uid && u = User.where(uid: uid).first)
+      u_params = update_params
+
+      u_params.delete(:email) if u_params[:email].blank?
+      Rails.logger.debug "Updating with #{u_params.inspect}"
+      begin
+        u.update_attributes(u_params)
+      rescue ActiveRecord::RecordNotUnique => e
+        u && u.errors.add(:base, 'Dupliate record')
+      end
+
+      if u.errors.blank?
+        render :json => u
+      else
+        Rails.logger.debug "Errors: #{u && u.errors.inspect}"
+        render :json => {}, :status => 422
+      end
+    else
+      render :json => {}, :status => 404
+    end
+  end
+
+  def destroy
+    id = params[:id]
+    uid = params[:uid]
+    u = nil
+    if (id && u=User.find(id)) || (uid && u = User.where(uid: uid).first)
+      render :json => u.destroy
+    else
+      render :json => nil, :status => 422
+    end
+  end
+
+  protected
+
+  def nillify_blanks(hash={})
+    hash.each { |k,v| hash[k]=nil if v.blank? }
+    hash
+  end
+
+  def search_params
+    nillify_blanks(params.permit(:email, :confirmation_token,
+     :unconfirmed_email, :remember_token))
+  end
+
+  def create_params
+    nillify_blanks(params.permit(:uid, :email, :encrypted_password,
+     :confirmation_sent_at, :confirmation_token))
+  end
+
+  def update_params
+    nillify_blanks(params.permit(:email, :password, :password_confirmation,
+     :confirmed_at, :created_at, :unconfirmed_email, :updated_at,
+     :encrypted_password, :confirmation_sent_at,
+     :confirmation_token, :current_sign_in_at, :current_sign_in_ip,
+     :failed_attempts, :last_sign_in_at, :last_sign_in_ip, :locked_at,
+     :remember_created_at, :remember_token, :reset_password_sent_at,
+     :reset_password_token, :sign_in_count, :uid, :unlock_token))
+  end
+end
+ 

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,0 +1,2 @@
+module UsersHelper
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 require 'api_constraints'
 
 Rails.application.routes.draw do
-  devise_for :users
+  #devise_for :users
 
   namespace :api, :defaults => {:format => :json} do
     scope :module => :v1, :constraints => ApiConstraints.new(:version => 1, :default => true) do
@@ -10,6 +10,12 @@ Rails.application.routes.draw do
       resources :tasks, :only => [:index, :create, :show, :update]
 #      resources :forms, :only => [:create, :show]
 #      get "credentials/verify" => "credentials#verify", :as => :verify_credentials
+    end
+  end
+
+  resources :users do
+    collection do
+      put '' => 'users#update'
     end
   end
 

--- a/db/migrate/20140619214815_add_remember_token_to_user.rb
+++ b/db/migrate/20140619214815_add_remember_token_to_user.rb
@@ -1,0 +1,7 @@
+class AddRememberTokenToUser < ActiveRecord::Migration
+  def change
+    add_column :users, :remember_token, :string
+
+    add_index "users", ["remember_token"], name: "index_users_on_remember_token"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140529184147) do
+ActiveRecord::Schema.define(version: 20140619214815) do
 
   create_table "app_oauth_scopes", force: true do |t|
     t.integer  "app_id"
@@ -173,10 +173,12 @@ ActiveRecord::Schema.define(version: 20140529184147) do
     t.datetime "locked_at"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.string   "remember_token"
   end
 
   add_index "users", ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true, using: :btree
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree
+  add_index "users", ["remember_token"], name: "index_users_on_remember_token", using: :btree
   add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
   add_index "users", ["uid"], name: "index_users_on_uid_and_provider", unique: true, using: :btree
   add_index "users", ["unlock_token"], name: "index_users_on_unlock_token", unique: true, using: :btree


### PR DESCRIPTION
This goes towards implementing #5.  The changes are to remove devise, since sessions are handled on the myusa-web server, and then to implement an API for the ReST requests from the myusa-web server.  Security has not been abled yet, so at this stage, anyone can create/update users using this API.
