### PR TITLE
Switch to a fork of pry-plus that's 2.1.x-compatible

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,7 +74,8 @@ group :development, :test do
   gem 'guard-migrate'
   gem 'guard-rspec'
   gem 'pry-rails'
-  gem 'pry-plus'
+  # this fork of pry-plus is 2.1.x-compatible
+  gem 'pry-plus', git: 'https://github.com/nhemsley/pry-plus.git'
   gem 'rb-fsevent' if `uname` =~ /Darwin/
   gem 'spring-commands-rspec'
 #  gem 'rspec_api_blueprint', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,6 +15,19 @@ GIT
   specs:
     validates_email_format_of (1.5.3)
 
+GIT
+  remote: https://github.com/nhemsley/pry-plus.git
+  revision: 7ad4a1ac48a68032f1afe3df79c5e54c1011c162
+  specs:
+    pry-plus (1.0.0)
+      bond
+      jist
+      pry-byebug
+      pry-doc
+      pry-docmore
+      pry-rescue
+      pry-stack_explorer
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -67,6 +80,9 @@ GEM
       slim (>= 1.3.6, < 3.0)
       terminal-table (~> 1.4)
     builder (3.2.2)
+    byebug (2.7.0)
+      columnize (~> 0.3)
+      debugger-linecache (~> 1.2)
     capistrano (3.2.1)
       i18n
       rake (>= 10.0.0)
@@ -106,12 +122,7 @@ GEM
     daemons (1.1.9)
     database_cleaner (1.2.0)
     debug_inspector (0.0.2)
-    debugger (1.6.6)
-      columnize (>= 0.3.1)
-      debugger-linecache (~> 1.2.0)
-      debugger-ruby_core_source (~> 1.3.2)
     debugger-linecache (1.2.0)
-    debugger-ruby_core_source (1.3.2)
     devise (3.2.4)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -229,23 +240,15 @@ GEM
       coderay (~> 1.0)
       method_source (~> 0.8)
       slop (~> 3.4)
-    pry-debugger (0.2.2)
-      debugger (~> 1.3)
-      pry (~> 0.9.10)
+    pry-byebug (1.3.2)
+      byebug (~> 2.7)
+      pry (~> 0.9.12)
     pry-doc (0.6.0)
       pry (~> 0.9)
       yard (~> 0.8)
     pry-docmore (0.1.1)
       pry
       pry-doc
-    pry-plus (1.0.0)
-      bond
-      jist
-      pry-debugger
-      pry-doc
-      pry-docmore
-      pry-rescue
-      pry-stack_explorer
     pry-rails (0.3.2)
       pry (>= 0.9.10)
     pry-rescue (1.4.1)
@@ -412,12 +415,11 @@ DEPENDENCIES
   omniauth-openid
   paperclip (~> 4.1)
   permanent_records (~> 2.3.0)
-  pry-plus
+  pry-plus!
   pry-rails
   quiet_assets
   railroady
   rails (= 4.1.0)
-  rb-fsevent
   rspec-rails (~> 3.0.0)
   ruby_parser
   rvm1-capistrano3


### PR DESCRIPTION
... thus avoiding `bundle install` snafus with the `debugger` gem.
