### PR TITLE
Remove conditional rb-fsevent dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -76,7 +76,6 @@ group :development, :test do
   gem 'pry-rails'
   # this fork of pry-plus is 2.1.x-compatible
   gem 'pry-plus', git: 'https://github.com/nhemsley/pry-plus.git'
-  gem 'rb-fsevent' if `uname` =~ /Darwin/
   gem 'spring-commands-rspec'
 #  gem 'rspec_api_blueprint', require: false
 end


### PR DESCRIPTION
It was screwing up diffs between Mac and Linux, and it isn't needed anyway because Listen imports everything
