### PR TITLE
Allow user to stay signed in across sessions

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,4 +1,5 @@
 class SessionsController < Devise::SessionsController
+  include Devise::Controllers::Rememberable
 
   before_action :authenticate_user_from_token!, only: [:new]
 
@@ -6,7 +7,7 @@ class SessionsController < Devise::SessionsController
     user = User.find_by_email(params[:user][:email]) ||
            User.create!(email: params[:user][:email])
 
-    user.set_authentication_token
+    token = user.set_authentication_token(remember_me: params[:user][:remember_me] == '1')
 
     # TODO: template with instructions for completing token authentication.
     render text: "CYM, #{user.email}"
@@ -20,12 +21,15 @@ class SessionsController < Devise::SessionsController
 
     return unless user && user.authentication_token
 
-    if user.authentication_sent_at &&
-       user.authentication_sent_at < 30.minutes.ago
-      # TODO: l10n
-      flash[:alert] = 'token expired'
+    if user.authentication_token_expired?
+      flash[:alert] = 'token expired' # TODO: l10n
     elsif user.verify_authentication_token(params[:token])
       user.expire_authentication_token
+
+      if params[:remember_me]
+        remember_me user
+      end
+
       sign_in_and_redirect user
     else
       logger.warn "Invalid token #{user.authentication_token} from user " +

--- a/app/mailers/devise_mailer.rb
+++ b/app/mailers/devise_mailer.rb
@@ -4,6 +4,7 @@ class DeviseMailer < Devise::Mailer
 
   def authentication_instructions(record, token, opts = {})
     @token = token
+    @remember_me = true if opts[:remember_me]
     devise_mail(record, :authentication_instructions, opts)
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,7 +17,7 @@ class User < ActiveRecord::Base
   before_validation :generate_uid
   after_create :create_profile
 
-  devise :omniauthable, :email_authenticatable
+  devise :omniauthable, :email_authenticatable, :rememberable
 
   attr_accessor :just_created, :auto_approve
 

--- a/app/views/devise_mailer/authentication_instructions.html.erb
+++ b/app/views/devise_mailer/authentication_instructions.html.erb
@@ -2,6 +2,6 @@
 
 <p>Someone has a token. Clicky clicky!</p>
 
-<p><%= link_to 'Clicky', new_user_session_url(email: @resource.email, token: @token).html_safe %></p>
+<p><%= link_to 'Clicky', new_user_session_url(email: @resource.email, token: @token, remember_me: @remember_me).html_safe %></p>
 
 <p>If you didn't request this, please ignore this email.</p>

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -21,11 +21,15 @@ describe SessionsController do
 
     context 'email and token are present' do
       let(:user) { User.create(email: email) }
+      let(:remember_me) { nil }
 
       context 'and are valid' do
         before :each do
           raw = user.set_authentication_token
-          get :new, :email => user.email, :token => raw
+          get :new,
+            :email => user.email,
+            :token => raw,
+            :remember_me => remember_me
         end
 
         it 'logs in and redirects the user' do
@@ -37,6 +41,21 @@ describe SessionsController do
         it 'expires the token' do
           expect(controller.current_user.authentication_token).to be_nil
         end
+
+        context 'remember_me is set' do
+          let(:remember_me) { true }
+
+          it 'sets the remember cookie' do
+            expect(@response.cookies).to have_key('remember_user_token')
+          end
+        end
+
+        context 'remember_me is not set' do
+          it 'does not set the remember cookie' do
+            expect(@response.cookies).to_not have_key('remember_user_token')
+          end
+        end
+
       end
 
       context 'token is bad' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -136,6 +136,21 @@ describe User, type: :model do
         :authentication_instructions, 'raw', anything)
       user.set_authentication_token
     end
+
+    context "called with remember_me option" do
+      it "ensures user has valid remember token" do
+        user.set_authentication_token(remember_me: true)
+        expect(user.remember_token).to be
+        expect(user).to_not be_remember_expired
+      end
+
+      it "passes remember_me option to devise mailer" do
+        expect(user).to receive(:send_devise_notification).with(
+          :authentication_instructions, 'raw', hash_including(:remember_me))
+        user.set_authentication_token(remember_me: true)
+      end
+
+    end
   end
 
   describe "#verify_authentication_token" do

--- a/spec/support/page_objects/sign_in_page.rb
+++ b/spec/support/page_objects/sign_in_page.rb
@@ -6,6 +6,7 @@ class SignInPage < SitePrism::Page
 
   element :slogan,           	'.slogan'
   element :email, 				    '#inputEmail3'
+  element :remember_me,       '#user_remember_me'
   element :google_button,     'a', :text => 'Sign in with Google'
   element :more_options,     	'.more-options'
   element :more_options_link,	'.more-options a'


### PR DESCRIPTION
- add devise rememberable
- set remember cookie after email authentication is successful and remember option is selected
- pass remember option through email notification
- use devise defaults for remember token settings
