### PR TITLE
Don't use Warden::Test::Helpers

### DIFF
--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -46,13 +46,13 @@ describe SessionsController do
           let(:remember_me) { true }
 
           it 'sets the remember cookie' do
-            expect(@response.cookies).to have_key('remember_user_token')
+            expect(response.cookies).to have_key('remember_user_token')
           end
         end
 
         context 'remember_me is not set' do
           it 'does not set the remember cookie' do
-            expect(@response.cookies).to_not have_key('remember_user_token')
+            expect(response.cookies).to_not have_key('remember_user_token')
           end
         end
 

--- a/spec/feature_helper.rb
+++ b/spec/feature_helper.rb
@@ -18,3 +18,8 @@ end
 Capybara.javascript_driver = :poltergeist
 
 Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }
+
+def login(user)
+  token = user.set_authentication_token
+  visit new_user_session_path(email: user.email, token: token)
+end

--- a/spec/features/devise/sessions/sign_in_spec.rb
+++ b/spec/features/devise/sessions/sign_in_spec.rb
@@ -3,7 +3,6 @@ require 'feature_helper'
 describe "Sign In" do
   describe "page" do
     before do
-      logout
       @page = SignInPage.new
       @page.load
     end
@@ -30,12 +29,24 @@ describe "Sign In" do
     end
   end
 
-  describe "with email" do
-    def sign_in_to_target(target_page, sign_in_page)
-      target_page.load
-      sign_in_page.google_button.click
+  describe "with an email address and token" do
+    let(:email) { 'testy@example.gov' }
+    let(:user) { User.create!(email: email) }
+
+    before :each do
+      @target_page = TargetPage.new
     end
 
+    it "visiting the new session url logs them in", :js => true do
+      token = user.set_authentication_token
+      visit new_user_session_path(email: user.email, token: token)
+
+      @target_page.load
+      expect(@target_page).to be_displayed
+    end
+  end
+
+  describe "with email" do
     before :each do
       @target_page = TargetPage.new
       @sign_in_page = SignInPage.new
@@ -173,7 +184,6 @@ describe "Sign In" do
 
       context "user has not signed in" do
         before :each do
-          logout
           @target_page.load
           @sign_in_page.google_button.click
         end

--- a/spec/requests/apis_spec.rb
+++ b/spec/requests/apis_spec.rb
@@ -17,7 +17,7 @@ describe "API" do
     @app = App.create(:name => 'App1', :redirect_uri => "http://localhost/")
     @app.oauth_scopes = OauthScope.where(:scope_type => 'user')
   end
-  
+
   describe "Token validity check" do
     subject { get "/api/profile", nil, {'HTTP_AUTHORIZATION' => "Bearer #{token}"} }
     context "with a valid token" do
@@ -122,7 +122,6 @@ describe "API" do
       @other_user = create_confirmed_user_with_profile(email: 'jane@citizen.org', first_name: 'Jane')
       @app2 = App.create!(:name => 'App2', :redirect_uri => "http://localhost:3000/")
       @app2.oauth_scopes << OauthScope.top_level_scopes
-      login(@user)
       1.upto(14) do |index|
         @notification = Notification.create!({:subject => "Notification ##{index}", :received_at => Time.now - 1.hour, :body => "This is notification ##{index}.", :user_id => @user.id, :app_id => @app.id})
       end
@@ -169,7 +168,7 @@ describe "API" do
       end
     end
   end
-  
+
   describe "Tasks API" do
     before do
       @token = build_access_token(@app)
@@ -239,7 +238,7 @@ describe "API" do
         end
       end
     end
-    
+
     describe "PUT /api/tasks:id.json" do
       context "when the caller has a valid token" do
         before do
@@ -278,7 +277,7 @@ describe "API" do
         end
       end
     end
-    
+
     describe "GET /api/tasks/:id.json" do
       before do
         @task = Task.create!({:name => 'New Task', :user_id => @user.id, :app_id => @app.id})
@@ -300,35 +299,32 @@ describe "API" do
       end
     end
   end
-  
   describe "Authorized Scopes API" do
     describe "GET /api/authorized_scopes" do
       context "when a valid token is provided" do
-        let(:scopes) do 
+        let(:scopes) do
           OauthScope.top_level_scopes.where(:scope_type => 'user') <<
             OauthScope.find_by_scope_name("profile.first_name") <<
             OauthScope.find_by_scope_name("profile.last_name")
         end
 
-        let(:scopes_selected) do 
+        let(:scopes_selected) do
           OauthScope.top_level_scopes.where(:scope_type => 'user') <<
             OauthScope.find_by_scope_name("profile.last_name")
         end
 
         let(:scope_app) do
-          App.create(name: 'app_limited', 
+          App.create(name: 'app_limited',
                      redirect_uri: "http://localhost/",
                      oauth_scopes: scopes)
         end
         let(:token) { build_access_token(scope_app, scopes_selected.map(&:scope_name).join(" ")) }
-    
+
         it "returns the list of scopes approved by user" do
-          login(@user)
-    
-          response = get "/api/authorized_scopes", nil, 
+          response = get "/api/authorized_scopes", nil,
                          {'HTTP_AUTHORIZATION' => "Bearer #{token}"}
-    
-          parsed_json = JSON.parse(response.body)     
+
+          parsed_json = JSON.parse(response.body)
           expected_scopes = scopes_selected.map(&:scope_name)
           expect(parsed_json.sort).to eql expected_scopes.sort
         end

--- a/spec/requests/oauth_request_spec.rb
+++ b/spec/requests/oauth_request_spec.rb
@@ -1,10 +1,11 @@
-require 'spec_helper'
+require 'rails_helper'
 
 describe 'OauthApps' do
-  let(:user) { create_confirmed_user_with_profile(email: 'first@user.org') }
+
+  let(:user) { create_confirmed_user_with_profile(email: 'somebody@user.org') }
 
   context 'when the user is logged in' do
-    before { login(user) }
+
     describe 'the client application' do
       let(:app_client_auth) do
         app = App.create(name: 'App1', custom_text: 'Custom text') do |a|
@@ -32,27 +33,6 @@ describe 'OauthApps' do
       describe 'receives a valid token' do
         its(:status) { should == 200 }
         its(:body)   { should include 'access_token' }
-      end
-    end
-
-    describe 'signing out of the app' do
-      pending 'sign out not implemented' do
-        subject { get(sign_out_path(continue: test_url)) }
-
-        context 'with a valid registered URL' do
-          let(:test_url) { 'http://app1host.com' }
-          it { should redirect_to(test_url) }
-        end
-
-        describe 'with an invalid registered url' do
-          let(:test_url) { 'http://xyz' }
-          it { should redirect_to(sign_in_url) }
-        end
-
-        describe 'with an unregistered url' do
-          let(:test_url) { 'http://apphost.com' }
-          it { should redirect_to(sign_in_url) }
-        end
       end
     end
   end

--- a/spec/support/request_helpers.rb
+++ b/spec/support/request_helpers.rb
@@ -1,20 +1,15 @@
 require 'spec_helper'
-include Warden::Test::Helpers
 
 def create_confirmed_user_with_profile(args={})
   profile = {
     email: 'joe@citizen.org',
-    first_name: 'Joe', last_name: 'Citizen', is_student: true
+    first_name: 'Joe',
+    last_name: 'Citizen',
+    is_student: true
   }.merge(args)
 
-  user = User.create!(email: profile[:email])
-
-  profile.delete(:email)
-
-  user.profile = Profile.new(profile)
-  user
-end
-
-def login(user)
-  login_as user, scope: :user
+  User.create! do |user|
+    user.email = profile.delete(:email)
+    user.profile = user.build_profile(profile)
+  end
 end


### PR DESCRIPTION
`Warden::Test::Helpers` were being included in controller specs, causing strange
issues. Upon further investigation, they were not needed in API request since
the API should use the authentication token, rather than session state to check
authentication, and feature specs use poltergeist for javascript enabled tests,
so this won't work there. Fix was to remove the `include Warden::Test::Helpers`
from spec_helper.rb, remove all login/logout from the API request specs, and to
implement a `login(user)` method that uses Capybara, rather than Rack::Test to
perform the login.
