### PR TITLE
Limit grant flows

### DIFF
--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -69,7 +69,7 @@ Doorkeeper.configure do
   #
   # If not specified, Doorkeeper enables all the four grant flows.
   #
-  # grant_flows %w(authorization_code implicit password client_credentials)
+  grant_flows %w(authorization_code)
 
   # Under some circumstances you might want to have applications auto-approved,
   # so that the user skips the authorization step.


### PR DESCRIPTION
For now MyUSA will only support `authorization_code` grant flow.
