### PR TITLE
Create helper for OAuth deny link

### DIFF
--- a/app/helpers/oauth_helper.rb
+++ b/app/helpers/oauth_helper.rb
@@ -1,0 +1,25 @@
+module OauthHelper
+  def oauth_deny_link(pre_auth, text)
+    error = Doorkeeper::OAuth::ErrorResponse.new(
+      state: pre_auth.state,
+      name: :access_denied,
+      redirect_uri: pre_auth.redirect_uri
+    )
+    if error.redirectable?
+      link_to text, error.redirect_uri
+    else
+      link_to(text, oauth_pre_auth_delete_uri(pre_auth), method: :delete)
+    end
+  end
+
+  def oauth_pre_auth_delete_uri(pre_auth)
+    oauth_authorization_path(
+      client_id: pre_auth.client.uid,
+      redirect_uri: pre_auth.redirect_uri,
+      state: pre_auth.state,
+      response_type: pre_auth.response_type,
+      scope: pre_auth.scope
+    )
+  end
+
+end

--- a/app/views/doorkeeper/authorizations/new.html.erb
+++ b/app/views/doorkeeper/authorizations/new.html.erb
@@ -11,7 +11,7 @@
     <span><b>No info for <%= @pre_auth.client.application.name %>?</b></span>
     <br>
     <p>
-      If you would like to proceed with your interaction with <%= @pre_auth.client.application.name %>, 
+      If you would like to proceed with your interaction with <%= @pre_auth.client.application.name %>,
       one of the following pieces of information to get your conversation started.
       <br>
       We've exposed all the context of their requests.
@@ -42,7 +42,7 @@
                   <%= text_field "new_profile_values", scope, placeholder: t("scopes.#{scope}.placeholder"), class:'form-control', style: 'width:40%;display:inline;'%>
                   <% else %>
                     <%= current_user.scope_field_value(scope)%>
-                  <% end %>              
+                  <% end %>
                 </span>
               </p>
             </li>
@@ -81,7 +81,7 @@
     <span><b>Still not convinced?</b></span>
     <br>
     <p>
-      Feel free to head back to <a>YOUR APP</a> <%= @pre_auth.client.application.name %></a>  or visit your <a href="#">MyUSA profile</a>.
+      Feel free to head back to <%= oauth_deny_link @pre_auth, @pre_auth.client.application.name %> or visit your <a href="#">MyUSA profile</a>.
     </p>
   </div>
   <br><br>

--- a/spec/features/doorkeeper/oauth_spec.rb
+++ b/spec/features/doorkeeper/oauth_spec.rb
@@ -85,9 +85,15 @@ describe 'OAuth' do
           expect(token).to_not be_expired
         end
 
-        scenario 'user can deny' do
+        scenario 'user can deny by clicking "No Thanks"' do
           expect(@auth_page).to be_displayed
           @auth_page.cancel_button.click
+          expect(JSON.parse(@auth_page.body)["error"]).to eq("access_denied")
+        end
+
+        scenario 'user can deny by clicking "head back to" link' do
+          expect(@auth_page).to be_displayed
+          @auth_page.head_back_link.click
           expect(JSON.parse(@auth_page.body)["error"]).to eq("access_denied")
         end
 

--- a/spec/support/page_objects/oauth2/authorization_page.rb
+++ b/spec/support/page_objects/oauth2/authorization_page.rb
@@ -10,5 +10,7 @@ class OAuth2::AuthorizationPage < SitePrism::Page
   element :allow_button, "input[value='Allow Access']"
   element :cancel_button, "input[value='No Thanks']"
 
+  element :head_back_link, "p[contains('head back to')]/a:first"
+
   element :error_message, "div.page-header[contains('An error has occurred')] ~ main"
 end


### PR DESCRIPTION
Hey @mikefab and @RyanRusnak ... this PR has the OAuth deny link that I promised. Just call the helper with a pre_auth object and some link text and it should all work. Let me know if you guys have any issues.

Helper creates a link that will send user back to calling app with access_denied. There is a little bit of hackery to support non-redirectable redirect_uri's ... that's to support the native_uri concept that Doorkeeper uses for testing. Specifically, that style of redirect link will send user to our deny route, which will render JSON. The main downside here is that it uses some Rails trickery to create a link that uses HTTP DELETE.
