### PR TITLE
Put the Devise return path in token auth link

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -7,7 +7,10 @@ class SessionsController < Devise::SessionsController
     user = User.find_by_email(params[:user][:email]) ||
            User.create!(email: params[:user][:email])
 
-    token = user.set_authentication_token(remember_me: params[:user][:remember_me] == '1')
+    token = user.set_authentication_token(
+      remember_me: params[:user][:remember_me] == '1',
+      return_to: stored_location_for(:user)
+    )
 
     # TODO: template with instructions for completing token authentication.
     render text: "CYM, #{user.email}"
@@ -30,7 +33,8 @@ class SessionsController < Devise::SessionsController
         remember_me user
       end
 
-      sign_in_and_redirect user
+      sign_in(:user, user)
+      redirect_to params[:return_to] || after_sign_in_path_for(user)
     else
       logger.warn "Invalid token #{user.authentication_token} from user " +
                   user.uid

--- a/app/mailers/devise_mailer.rb
+++ b/app/mailers/devise_mailer.rb
@@ -5,6 +5,7 @@ class DeviseMailer < Devise::Mailer
   def authentication_instructions(record, token, opts = {})
     @token = token
     @remember_me = true if opts[:remember_me]
+    @return_to = opts[:return_to]
     devise_mail(record, :authentication_instructions, opts)
   end
 

--- a/app/views/devise_mailer/authentication_instructions.html.erb
+++ b/app/views/devise_mailer/authentication_instructions.html.erb
@@ -2,6 +2,6 @@
 
 <p>Someone has a token. Clicky clicky!</p>
 
-<p><%= link_to 'Clicky', new_user_session_url(email: @resource.email, token: @token, remember_me: @remember_me).html_safe %></p>
+<p><%= link_to 'Clicky', new_user_session_url(email: @resource.email, token: @token, remember_me: @remember_me, return_to: @return_to).html_safe %></p>
 
 <p>If you didn't request this, please ignore this email.</p>

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -25,6 +25,10 @@ describe SessionsController do
 
       context 'and are valid' do
         before :each do
+          if self.respond_to?(:return_to)
+            controller.store_location_for(:user, return_to)
+          end
+
           raw = user.set_authentication_token
           get :new,
             :email => user.email,
@@ -32,14 +36,26 @@ describe SessionsController do
             :remember_me => remember_me
         end
 
-        it 'logs in and redirects the user' do
+        it 'logs in the user' do
           expect(controller.current_user).to be
           expect(controller.current_user.email).to eq(user.email)
-          expect(response).to redirect_to(root_path)
         end
 
         it 'expires the token' do
           expect(controller.current_user.authentication_token).to be_nil
+        end
+
+        context 'return to path is not set' do
+          it 'redirects to the root path' do
+            expect(response).to redirect_to(root_path)
+          end
+        end
+        context 'return to path is set' do
+          let(:return_to) { secret_path }
+
+          it 'redirects to the return path' do
+            expect(response).to redirect_to(return_to)
+          end
         end
 
         context 'remember_me is set' do
@@ -55,7 +71,6 @@ describe SessionsController do
             expect(response.cookies).to_not have_key('remember_user_token')
           end
         end
-
       end
 
       context 'token is bad' do


### PR DESCRIPTION
If user is sent to the MyUSA login form while they are in the middle of something, we need to be able to keep the return path. So, pass it as an option to the token generation method and then stash it in the email link that we send to users. Then, when the token is authenticated, look for the return path, and if present redirect back to it.
