### PR TITLE
Enable coverage & test results in Shippable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,14 +13,12 @@ install:
 before_script:
   - cp config/database.yml.example config/database.yml
   - cp config/secrets.yml.example config/secrets.yml
+  - mkdir -p shippable/testresults
+  - mkdir -p shippable/codecoverage
 script:
   - RAILS_ENV=test bundle exec rake db:setup
-  - bundle exec rake spec
+  - bundle exec rspec --format RspecJunitFormatter -o shippable/testresults/results.xml
 after_failure:
-  - mysql -e 'show databases;'
-  - cat ./config/database.yml
-  - echo $RAILS_ENV
-  - bundle exec rake --version
   - python other/slack/slack_notifier.py --project $PROJECT --org $SLACK_ORG --token $SLACK_TOKEN
 notifications:
   email:

--- a/Gemfile
+++ b/Gemfile
@@ -107,6 +107,8 @@ group :test do
   gem 'rspec-its'
   gem 'shoulda-matchers'
   gem 'simplecov', require: false
+  gem 'simplecov-csv', require: false
+  gem 'rspec_junit_formatter', require: false # used by Shippable
   gem 'timecop'
   gem 'capybara-email'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -483,6 +483,10 @@ GEM
       rspec-mocks (~> 3.0.0)
       rspec-support (~> 3.0.0)
     rspec-support (3.0.0)
+    rspec_junit_formatter (0.2.0)
+      builder (< 4)
+      rspec (>= 2, < 4)
+      rspec-core (!= 2.12.0)
     rubocop (0.24.1)
       json (>= 1.7.7, < 2)
       parser (>= 2.2.0.pre.3, < 3.0)
@@ -527,6 +531,8 @@ GEM
       docile (~> 1.1.0)
       multi_json
       simplecov-html (~> 0.8.0)
+    simplecov-csv (0.1.3)
+      simplecov
     simplecov-html (0.8.0)
     site_prism (2.6)
       addressable (~> 2.3.3)
@@ -656,6 +662,7 @@ DEPENDENCIES
   rails (= 4.1.0)
   rspec-its
   rspec-rails (~> 3.0.0)
+  rspec_junit_formatter
   rubocop
   ruby_parser
   sass-rails (~> 4.0.3)
@@ -663,6 +670,7 @@ DEPENDENCIES
   secure_headers
   shoulda-matchers
   simplecov
+  simplecov-csv
   site_prism
   slim
   spring

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,14 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
-ENV["RAILS_ENV"] ||= 'test'
+ENV['RAILS_ENV'] ||= 'test'
+
+require 'simplecov'
+if ENV['COVERAGE_REPORTS']
+  require 'simplecov-csv'
+  SimpleCov.coverage_dir ENV['COVERAGE_REPORTS']
+  SimpleCov.formatter = SimpleCov::Formatter::CSVFormatter
+end
+SimpleCov.start 'rails' # has to start before application is loaded
+
 require File.expand_path("../../config/environment", __FILE__)
 require 'rspec/rails'
 require 'rspec/its'


### PR DESCRIPTION
Coverage isn't much use in Shippable yet, but if you run `rspec` locally you'll get a nice page to look at in `coverage/index.html`.
