### PR TITLE
AuthenticationToken cache_key should be based on token, rather than user

### DIFF
--- a/lib/email_authenticatable.rb
+++ b/lib/email_authenticatable.rb
@@ -21,11 +21,10 @@ module Devise
 
       def authenticate!
         user = params[:email].present? && User.find_by_email(params[:email])
-        
-        @token = AuthenticationToken.find_by_user_id(user && user.id)
-        @token.raw = params[:token]
 
-        if validate(user) { @token.valid? }
+        @token = AuthenticationToken.find(params[:token])
+
+        if validate(user) { @token.valid? && @token.user_id == user.id }
           @token.delete
 
           session['user_return_to'] = @token.return_to if @token.return_to.present?
@@ -36,7 +35,7 @@ module Devise
       end
 
       def remember_me?
-        @token.remember_me
+        !!@token.remember_me
       end
     end
   end

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -24,7 +24,7 @@ describe SessionsController do
 
       context 'and are valid' do
         before :each do
-          token = AuthenticationToken.generate(
+          @token = AuthenticationToken.generate(
             user_id: user.id,
             remember_me: self.respond_to?(:remember_me) ? remember_me : nil,
             return_to: self.respond_to?(:return_to) ? return_to : nil
@@ -32,7 +32,7 @@ describe SessionsController do
 
           get :new,
             :email => user.email,
-            :token => token.raw
+            :token => @token.raw
         end
 
         it 'logs in the user' do
@@ -41,7 +41,7 @@ describe SessionsController do
         end
 
         it 'expires the token' do
-          expect(AuthenticationToken.find_by_user_id(user.id)).to_not be_valid
+          expect(AuthenticationToken.find(@token.raw)).to_not be_valid
         end
 
         context 'return to path is not set' do
@@ -77,11 +77,13 @@ describe SessionsController do
 
   describe '#create' do
     shared_examples "token creation" do
-
       it 'creates a token' do
-        expect(AuthenticationToken.find_by_user_id(@user.id)).to be
+        expect(AuthenticationToken).to have_received(:generate)
       end
+    end
 
+    before :each do
+      allow(AuthenticationToken).to receive(:generate).and_call_original
     end
 
     context 'when user does not exist' do

--- a/spec/models/authentication_token_spec.rb
+++ b/spec/models/authentication_token_spec.rb
@@ -18,31 +18,30 @@ describe AuthenticationToken, type: :model do
 
   describe '#save' do
     let(:token) { AuthenticationToken.create(user_id: 1) }
-    # end
 
     it 'writes token to cache' do
-      expect(Rails.cache.fetch(token.send(:cache_key))).to be
+      expect(Rails.cache.fetch(AuthenticationToken.send(:cache_key, token.raw))).to be
     end
 
     it 'omits raw token' do
-      expect(Rails.cache.fetch(token.send(:cache_key))[:raw]).to be_nil
+      expect(Rails.cache.fetch(AuthenticationToken.send(:cache_key, token.raw))[:raw]).to be_nil
     end
   end
 
-  describe '#find_by_user_id' do
+  describe '#find' do #_by_user_id' do
     it 'finds a token if there is one' do
       token = AuthenticationToken.new(user_id: 1)
       token.save
 
-      found_token = AuthenticationToken.find_by_user_id(1)
+      found_token = AuthenticationToken.find(token.raw)
       expect(found_token).to be_a(AuthenticationToken)
       expect(found_token.user_id).to eq(1)
     end
     it 'returns an empty token if none exists' do
-      expect(AuthenticationToken.find_by_user_id(11)).to be_a(AuthenticationToken)
+      expect(AuthenticationToken.find('foobar')).to be_a(AuthenticationToken)
     end
     it 'returns an empty token if nothing is passed' do
-      expect(AuthenticationToken.find_by_user_id(nil)).to be_a(AuthenticationToken)
+      expect(AuthenticationToken.find(nil)).to be_a(AuthenticationToken)
     end
   end
 
@@ -50,7 +49,7 @@ describe AuthenticationToken, type: :model do
     it 'destoys the cached token' do
       token = AuthenticationToken.generate(user_id: 1)
       token.delete
-      expect(Rails.cache.fetch(token.send(:cache_key))).to be_nil
+      expect(Rails.cache.fetch(AuthenticationToken.send(:cache_key, token.raw))).to be_nil
     end
   end
 


### PR DESCRIPTION
Token should be based on token, rahter than user, so that creation of a new token does not invalidate old token.
