### PR TITLE
Create tests for multiple live token cases

### DIFF
--- a/spec/features/devise/sessions/sign_in_spec.rb
+++ b/spec/features/devise/sessions/sign_in_spec.rb
@@ -166,7 +166,6 @@ describe "Sign In" do
       end
 
       shared_examples "omniauth" do
-
         it "redirects the user to the next point" do
           expect(@target_page).to be_displayed
           expect(@target_page.source).to match secret
@@ -177,7 +176,6 @@ describe "Sign In" do
           expect(@target_page).to be_displayed
           expect(@target_page.source).to match secret
         end
-
       end
 
       context "user has already signed in with google" do


### PR DESCRIPTION
WIP DO NOT MERGE
- test to ensure that token is valid even after user requests multiple other tokens
- (pending) test to ensure that other tokens are invalidated

addressing @polastre's comments in #205 ...

when: generate token 1 and then generate token 2
ensure:
- log in with token 1 (it still works)
- token 2 is either invalidated or expires (either one)

login in with token 1 (or any token) works and test for it is at https://github.com/18F/myusa/blob/328fc6281279bbdfa179e2fe97210b62f7af9fc1/spec/lib/email_authenticatable_spec.rb#L98-L105

invalidate/expire all other tokens, test is at https://github.com/18F/myusa/blob/328fc6281279bbdfa179e2fe97210b62f7af9fc1/spec/lib/email_authenticatable_spec.rb#L107-L109 ...

 it is pending b/c right now i can't look tokens up by user (because they are keyed off of user id in the cache). if we want to query by either user or hashed token, we should consider putting these back in the database ... 

going to move tokens to mysql so that they can be queried for
