### PR TITLE
Client application should not have to specify scope

### DIFF
--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -124,7 +124,9 @@ module OAuthValidations
   end
 
   def validate_scopes
-    super && Doorkeeper::OAuth::Helpers::ScopeChecker.valid?(scope, client.application.scopes)
+    return true unless scope.present?
+    Doorkeeper::OAuth::Helpers::ScopeChecker.valid?(scope, server.scopes) &&
+      Doorkeeper::OAuth::Helpers::ScopeChecker.valid?(scope, client.application.scopes)
   end
 
   def validate_client

--- a/spec/lib/doorkeeper/pre_authorization_spec.rb
+++ b/spec/lib/doorkeeper/pre_authorization_spec.rb
@@ -1,0 +1,59 @@
+require 'spec_helper'
+
+module Doorkeeper::OAuth
+  describe PreAuthorization do
+    let(:server) { Doorkeeper.configuration }
+
+    let(:client_app) { FactoryGirl.create(:application, public: true) }
+    let(:client) do
+      c = double(:client,
+        redirect_uri: 'http://www.example.com',
+        application: client_app
+      )
+      allow(c).to receive(:valid_for?).and_return(true)
+      c
+    end
+
+    let(:user) { FactoryGirl.create(:user) }
+
+    let(:scopes) { 'profile.email' }
+
+    let(:attributes) do
+      {
+        response_type: 'code',
+        redirect_uri: 'http://www.example.com',
+        state: 'save-this',
+        scope: scopes
+      }
+    end
+
+    subject do
+      PreAuthorization.new(server, client, user, attributes)
+    end
+
+    context 'when there are no scopes' do
+      it 'is valid' do
+        expect(subject).to be_authorizable
+      end
+    end
+
+    context 'when scopes are present' do
+      let(:scopes) { 'profile.email profile.first_name' }
+
+      context 'and invalid for application' do
+        let(:client_app) { FactoryGirl.create(:application, scopes: 'profile.city') }
+        it 'is invalid' do
+          expect(subject).to_not be_authorizable
+        end
+      end
+
+      context 'and valid for application' do
+        let(:client_app) { FactoryGirl.create(:application, scopes: 'profile.email profile.first_name profile.last_name') }
+        it 'is valid' do
+          expect(subject).to be_authorizable
+        end
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
If client application does not ask for any scopes, pre-authorization should pass.

this is for https://github.com/18F/myusa/issues/221
