### PR TITLE
Skip Authorization if no scopes are requested

### DIFF
--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -71,12 +71,10 @@ Doorkeeper.configure do
   #
   grant_flows %w(authorization_code)
 
-  # Under some circumstances you might want to have applications auto-approved,
-  # so that the user skips the authorization step.
-  # For example if dealing with trusted a application.
-  # skip_authorization do |resource_owner, client|
-  #   client.superapp? or resource_owner.admin?
-  # end
+  # Skip authorization when no scopes are requested ...
+  skip_authorization do |resource_owner, client|
+    pre_auth.scopes.to_a.empty?
+  end
 
   # WWW-Authenticate Realm (default "Doorkeeper").
   realm "MyUSA"

--- a/spec/features/doorkeeper/oauth_spec.rb
+++ b/spec/features/doorkeeper/oauth_spec.rb
@@ -32,6 +32,13 @@ describe 'OAuth' do
     end
   end
 
+  shared_examples 'uses existing authorization' do
+    it 'skips authorization' do
+      token = @token_page.get_token(oauth_client, client_app.redirect_uri)
+      expect(token).to_not be_expired
+    end
+  end
+
   before :each, authorized: true do
     FactoryGirl.create(:access_token,
                         application: client_app,
@@ -123,15 +130,14 @@ describe 'OAuth' do
             expect(@auth_page.flash_error_message).to have_content("Phone number")
           end
         end
+
+        context 'when no scopes are requested' do
+          let(:requested_scopes) { '' }
+          it_behaves_like 'uses existing authorization'
+        end
       end
 
       context 'when user is already authorized', authorized: true do
-        shared_examples 'uses existing authorization' do
-          it 'uses existing authorization' do
-            token = @token_page.get_token(oauth_client, client_app.redirect_uri)
-            expect(token).to_not be_expired
-          end
-        end
 
         context 'with the same set of scopes requested' do
           let(:authorized_scopes) { requested_scopes }


### PR DESCRIPTION
Doorkeeper will bypass authorization when no scopes are requested.
