### PR TITLE
Don't show scope groups for groups not requested

### DIFF
--- a/app/helpers/scopes_helper.rb
+++ b/app/helpers/scopes_helper.rb
@@ -28,7 +28,7 @@ module ScopesHelper
 
   def scopes_by_group(scopes)
     SCOPE_GROUPS.each do |scope_group|
-      filtered_scopes =  scopes.select {|s| scope_group[:scopes].include?(s) }
+      filtered_scopes = scopes.select { |s| scope_group[:scopes].include?(s) }
       yield(scope_group[:name], filtered_scopes)
     end
   end

--- a/app/views/doorkeeper/authorizations/_scope_list.html.erb
+++ b/app/views/doorkeeper/authorizations/_scope_list.html.erb
@@ -1,5 +1,6 @@
 <ul class="list-unstyled scope-list">
   <% scopes_by_group(@pre_auth.scopes) do |group, scopes| %>
+    <% if scopes.length > 0 %>
     <li>
       <h2 class="open"><%= t("scope_groups.#{group}.description") %></h2>
       <div class="form-group">
@@ -15,5 +16,6 @@
         <% end %>
       </div>
     </li>
+    <% end %>
   <% end %>
 </ul>


### PR DESCRIPTION
If the filtered scopes (requested scopes) for a particular
scope group is empty, don't show the scope group `<li>`
and `<h2>` tags (don't show the group at all, really).
