### PR TITLE
Add legal documentation to MyUSA & link from footer

### DIFF
--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -6,7 +6,7 @@
           <%= image_tag "header-logo.png", :width => 53, :height => 15 %>
         </li>
         <li>
-          <%= link_to 'Terms & Privacy', '#', :title => 'Terms & Privacy' %>
+          <%= link_to 'Terms & Privacy', '/legal.html', :title => 'Terms & Privacy' %>
         </li>
         <li>
           <%= link_to 'FAQs', '#', :title => 'Frequently Asked Questions' %>

--- a/lib/tasks/legal_docs.rake
+++ b/lib/tasks/legal_docs.rake
@@ -1,0 +1,39 @@
+SOURCE_FILES = Rake::FileList[
+  "public/legal/overview.md",
+  "public/legal/terms.md",
+  "public/legal/privacy.md",
+  "public/legal/linking.md",
+  "public/legal/pra.md"
+]
+
+file "public/legal.md" => SOURCE_FILES do |t|
+  puts "merging source markdown files"
+  File.open("public/legal.md", 'w') do |f|
+    f.puts t.sources.map {|md| IO.read(md) }
+  end
+end
+
+rule ".html" => ".md" do |t|
+  puts "generating #{t.name}"
+  system 'aglio', '-i', t.source, '-o', t.name
+end
+
+namespace :legal_docs do
+  desc 'generate legal documentation'
+  task :generate => "public/legal.html"
+
+
+  desc 'remove generated HTML and markdown'
+  task :clean do
+    files = Rake::FileList['public/legal.md', 'public/legal.html']
+    files.each do |f|
+      if File.exists?(f)
+        puts "deleting #{f}"
+        File.delete(f)
+      end
+    end
+  end
+
+  desc 'clean and regenerate legal documentation'
+  task :regenerate => [:clean, :generate]
+end

--- a/public/legal.html
+++ b/public/legal.html
@@ -1,0 +1,208 @@
+<!DOCTYPE html><html><head><meta charset="utf-8"><title>MyUSA Legal Notices</title><link rel="stylesheet" href="//netdna.bootstrapcdn.com/bootstrap/3.1.1/css/bootstrap.min.css"><link rel="stylesheet" href="//netdna.bootstrapcdn.com/font-awesome/4.0.3/css/font-awesome.min.css"><link rel="stylesheet" href="//fonts.googleapis.com/css?family=Roboto:400,700|Inconsolata|Raleway:200"><style>/* Highlight.js Theme Tomorrow */
+.hljs-comment,.hljs-title{color:#8e908c}.hljs-variable,.hljs-attribute,.hljs-tag,.hljs-regexp,.ruby .hljs-constant,.xml .hljs-tag .hljs-title,.xml .hljs-pi,.xml .hljs-doctype,.html .hljs-doctype,.css .hljs-id,.css .hljs-class,.css .hljs-pseudo{color:#c82829}.hljs-number,.hljs-preprocessor,.hljs-pragma,.hljs-built_in,.hljs-literal,.hljs-params,.hljs-constant{color:#f5871f}.ruby .hljs-class .hljs-title,.css .hljs-rules .hljs-attribute{color:#eab700}.hljs-string,.hljs-value,.hljs-inheritance,.hljs-header,.ruby .hljs-symbol,.xml .hljs-cdata{color:#718c00}.css .hljs-hexcolor{color:#3e999f}.hljs-function,.python .hljs-decorator,.python .hljs-title,.ruby .hljs-function .hljs-title,.ruby .hljs-title .hljs-keyword,.perl .hljs-sub,.javascript .hljs-title,.coffeescript .hljs-title{color:#4271ae}.hljs-keyword,.javascript .hljs-function{color:#8959a8}.hljs{display:block;background:white;color:#4d4d4c;padding:.5em}.coffeescript .javascript,.javascript .xml,.tex .hljs-formula,.xml .javascript,.xml .vbscript,.xml .css,.xml .hljs-cdata{opacity:.5}</style><style>body,
+h4,
+h5 {
+  font-family: 'Roboto' sans-serif !important;
+}
+h1,
+h2,
+h3,
+.aglio {
+  font-family: 'Raleway' sans-serif !important;
+}
+h1 a,
+h2 a,
+h3 a,
+h4 a,
+h5 a {
+  display: none;
+}
+h1:hover a,
+h2:hover a,
+h3:hover a,
+h4:hover a,
+h5:hover a {
+  display: inline;
+}
+code {
+  color: #444;
+  background-color: #ddd;
+  font-family: 'Inconsolata' monospace !important;
+}
+a[data-target] {
+  cursor: pointer;
+}
+h4 {
+  font-size: 100%;
+  font-weight: bold;
+  text-transform: uppercase;
+}
+.back-to-top {
+  position: fixed;
+  z-index: 1;
+  bottom: 0px;
+  right: 24px;
+  padding: 4px 8px;
+  background-color: #eee;
+  text-decoration: none !important;
+  border-top: 1px solid rgba(0,0,0,0.1);
+  border-left: 1px solid rgba(0,0,0,0.1);
+  border-right: 1px solid rgba(0,0,0,0.1);
+  border-top-left-radius: 3px;
+  border-top-right-radius: 3px;
+}
+.panel {
+  overflow: hidden;
+}
+.panel-heading code {
+  color: #c7254e;
+  background-color: transparent;
+  white-space: pre-wrap;
+  white-space: -moz-pre-wrap;
+  white-space: -pre-wrap;
+  white-space: -o-pre-wrap;
+  word-wrap: break-word;
+}
+.panel-heading h3 {
+  margin-top: 10px;
+  margin-bottom: 10px;
+}
+a.list-group-item {
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+}
+a.list-group-item.heading {
+  background-color: #f5f5f5;
+}
+.list-group-item.collapse {
+  display: none;
+}
+.list-group-item.collapse.in {
+  display: block;
+}
+#nav {
+  margin-top: 38px;
+  min-width: 255px;
+  top: 0;
+  bottom: 0;
+  padding-right: 12px;
+  padding-bottom: 12px;
+  overflow-y: auto;
+}
+@media (max-width: 1199px) {
+  #nav {
+    min-width: 212px;
+  }
+}
+</style></head><body><a href="#top" class="text-muted back-to-top"><i class="fa fa-toggle-up"></i>&nbsp;Back to top</a><div class="container"><div class="row"><div class="col-md-3"><nav id="nav" class="hidden-sm hidden-xs affix nav"><div class="list-group"><a href="#terms-of-service" class="list-group-item heading">Terms of service</a></div><div class="list-group"><a href="#privacy-policy" class="list-group-item heading">Privacy policy</a></div><div class="list-group"><a href="#linking-policy" class="list-group-item heading">Linking policy</a></div><div class="list-group"><a href="#pra-statement" class="list-group-item heading">PRA Statement</a></div></nav></div><div class="col-md-9"><div><header><div class="page-header"><h1 id="top">MyUSA Legal Notices</h1></div></header><div class="description"><p>This document contains the legal notices regarding the MyUSA service.  This includes MyUSA’s policies on linking, privacy, collection of information, terms of service, and security.</p>
+</div></div><div><div class="panel panel-default"><div class="panel-heading"><h3 id="terms-of-service">Terms of service&nbsp;<a href="#terms-of-service"><i class="fa fa-link"></i></a></h3></div><div class="panel-body"><p>The <a href="http://www.gsa.gov">General Services Administration</a> (“GSA”) develops and maintains MyUSA, a shared service that simplifies interacting with the Federal government online. MyUSA is provided “as-is” and entirely free. </p>
+<h2 id="scope">Scope</h2>
+<p>MyUSA (hereafter, the “Service”) provides users with a persistent online persona to interact with government services. MyUSA is offered subject to your acceptance of the terms and conditions contained herein as well as any relevant sections of the <a href="#privacy-policy">MyUSA Privacy Policy</a> (collectively, the “Agreement”). The Service is made available to individuals who are at least 18 years of age. Use of MyUSA, either by public individuals, entities, or Federal agencies, constitutes acceptance to this Agreement.</p>
+<p>Please be sure to read this Agreement carefully before using this website or its related services. If you do not agree to all the terms and conditions of this Agreement, then you may not access the website or use the services it provides.</p>
+<p>All of the services, content, documentation, code and related materials made available to you through the Service are subject to these terms. Access to or use of the Service or its content, whether directly or programmatically (e.g., via an application programming interface (API) or third-party application), constitutes acceptance to this Agreement.</p>
+<h2 id="use">Use</h2>
+<p>You may use any MyUSA service directly or via third-party applications to store profile and related information, and to search, display, analyze, retrieve, view or otherwise “get” any information made available by the Service.</p>
+<p>If you are entering into this agreement on behalf of a company, Federal agency, or other legal entity, you represent that you have the authority to bind such entity, its affiliates and all users who access our services through your account to the Agreement, in which case the terms “you” or “your” shall refer to such entity, its affiliates and users associated with it. If you do not have such authority, or if you do not agree with the Agreement, you must not accept this Agreement and may not use the services.</p>
+<h2 id="attribution">Attribution</h2>
+<p>While not required, when using content, data, documentation, code, and related materials from MyUSA in your own work, we ask that proper credit be given. An example citation is provided below:</p>
+<p><em>Powered by <a href="https://my.usa.gov">MyUSA</a></em></p>
+<p>You may use the MyUSA name or logos in order to identify the source of the content or service subject to these rules. You may not use the MyUSA name, logo, or the like to imply endorsement of any product, service, or entity, not-for-profit, commercial or otherwise. GSA will not be liable for any false statements or misrepresentations made by you or on your behalf as a result of your use of the Service.</p>
+<h2 id="your-account">Your account</h2>
+<p>If you create a MyUSA account (or log in to the Service using a third-party login) or integrate MyUSA into an application, you are responsible for maintaining the security of your account or application and are fully responsible for the activities that occur any actions taken therein. You must immediately notify MyUSA of any unauthorized use of your account or breaches of security. GSA will not be liable for any acts or omissions by you, including any damages of any kind incurred as a result of such acts or omissions.</p>
+<h2 id="the-information-you-submit">The information you submit</h2>
+<p>The information you submit will remain private to you, unless you explicitly authorize an application or agency to use it at the time. It is your responsibility to ensure the information submitted to agencies and other government entities, by you or on your behalf, is and remains factual, complete, and accurate.</p>
+<h2 id="modification-or-false-representation-of-content">Modification or false representation of content</h2>
+<p>You may not modify or falsely represent content accessed through the Service and still claim the source is MyUSA.</p>
+<h2 id="right-to-limit">Right to limit</h2>
+<p>Your use of the Service may be subject to certain limitations on access, calls, or use as set forth within this Agreement or otherwise provided by MyUSA. If GSA reasonably believes that you have attempted to exceed or circumvent these limits, your ability to use the Service may be permanently or temporarily blocked. GSA may monitor your use of the Service to improve the application or to insure compliance with this Agreement.</p>
+<h2 id="service-termination">Service termination</h2>
+<p>If you wish to terminate this Agreement, you may do so by refraining from further use of MyUSA. GSA reserves the right (though not the obligation) to refuse to provide MyUSA to you if it is GSA’s opinion that use violates any GSA or Federal policy or law. GSA also reserves the right to stop providing MyUSA at any time for any reason in its sole discretion. All provisions of this Agreement, which by their nature should survive termination, shall survive termination including warranty disclaimers and limitations of liability.</p>
+<h2 id="changes">Changes</h2>
+<p>GSA reserves the right, at its sole discretion, to modify or replace this Agreement, in whole or in part. Your continued use of or access to MyUSA following posting of any changes to this Agreement constitutes acceptance of those modified terms. MyUSA may, in the future, offer new capabilities and/or features through the MyUSA. Such new features and/or capabilities shall be subject to the terms and conditions of this Agreement.</p>
+<h2 id="disclaimer-of-warranties">Disclaimer of warranties</h2>
+<p>MyUSA is provided “as is” and on an “as-available” basis. GSA will do its best to ensure MyUSA is available and functional as much as possible, GSA hereby disclaim all warranties of any kind, express or implied, including without limitation the warranties of merchantability, fitness for a particular purpose, and non-infringement. GSA makes no warranty that MyUSA data will be error free or that access thereto will be continuous or uninterrupted.</p>
+<h2 id="limitations-on-liability">Limitations on liability</h2>
+<p>In no event will GSA be liable with respect to any subject matter of this Agreement under any contract, negligence, strict liability or other legal or equitable theory for: (1) any special, incidental, or consequential damages; (2) the cost of procurement of substitute products or services; or (3) for interruption of use or loss or corruption of data.</p>
+<h2 id="miscellaneous">Miscellaneous</h2>
+<p>This Agreement constitutes the entire Agreement between GSA and you concerning the subject matter hereof, and may only be modified by the posting of a revised version on this page by GSA.</p>
+<h2 id="disputes">Disputes</h2>
+<p>Any disputes arising out of this Agreement and access to or use of the Service shall be governed by federal law.</p>
+<h2 id="no-waiver-of-rights">No waiver of rights</h2>
+<p>GSA’s failure to exercise or enforce any right or provision of this Agreement shall not constitute waiver of such right or provision.</p>
+<h2 id="security">Security</h2>
+<p>If you represent a Federal agency and would like to understand the <a href="http://csrc.nist.gov/groups/SMA/fisma/framework.html">risk management framework</a> of MyUSA under the Federal Information Security Management Act, please email GSA@gsa.gov with the subject line <em>MyUSA FISMA Status</em>.</p>
+</div></div></div><div><div class="panel panel-default"><div class="panel-heading"><h3 id="privacy-policy">Privacy policy&nbsp;<a href="#privacy-policy"><i class="fa fa-link"></i></a></h3></div><div class="panel-body"><p>We hold your privacy in the highest regard. MyUSA collects some anonymous information automatically to help us improve the service (such as what parts of our system are being used when). MyUSA also gives you an option to provide basic personal information, which we’ll use to customize your experience and simplify many common tasks. MyUSA has a few fundamental principles:</p>
+<ol>
+<li>Your personal information will only be used to improve or customize your experience.</li>
+<li>The information you provide is your information and you have the ultimate say in how it’s used.</li>
+<li>We’ll always ask before we share your information with an agency or other government entity, and unless you say otherwise, it will remain private to you (except where required by law, as detailed in our <a href="http://www.gpo.gov/fdsys/pkg/FR-2013-07-05/pdf/2013-16124.pdf">System of Records Notice</a>).</li>
+<li>We never store personal information on our servers unless required for the on-going operation of one of our services.</li>
+</ol>
+<h2 id="generally">Generally</h2>
+<p>We are committed to protecting the privacy of our users. We collect no personal information unless you choose to provide that information to us.</p>
+<h2 id="information-collected-automatically">Information collected automatically</h2>
+<p>Like most website operators, as you use our service, either directly or indirectly, we may collect and store the following non-personally-identifiable (a.k.a. anonymous) information about your visit:</p>
+<ul>
+<li>the date and time you access MyUSA;</li>
+<li>the various components of MyUSA you access;</li>
+<li>if you access the MyUSA from another website or application - the identity of that third-party;</li>
+<li>the technical capabilities of the computer you use to access our site, and</li>
+<li>the IP address (an anonymous number automatically assigned to your computer whenever you are surfing the internet) from which you access MyUSA.</li>
+</ul>
+<p>We use this information, in the aggregate, to make MyUSA more useful to users — to learn about the number of and type of users of MyUSA, the components utilized, the types of technology used, to detect operational problems, and to improve MyUSA’s overall security.</p>
+<h2 id="information-that-you-provide-voluntarily">Information that you provide voluntarily</h2>
+<p>Certain users of our service choose to interact with it in ways that require us to gather personally-identifying information. The amount and type of information that we gather depends on the nature of the interaction. For example, if you add your name and street address to your MyUSA profile, we may offer to pre-fill common fields as you complete a form. In each case, we collect such information only insofar as is necessary or appropriate to fulfill the purpose of the user’s interaction with us. We do not disclose personally-identifying information other than as described in our <a href="http://www.gpo.gov/fdsys/pkg/FR-2013-07-05/pdf/2013-16124.pdf">System of Records Notice</a>. Users may refuse to supply personally-identifying information at any time, with the understanding that it may prevent them from engaging in certain website-related activities.</p>
+<h2 id="login-information">Login information</h2>
+<p>When using our Service, you may be prompted with the opportunity to create a MyUSA account, or use an existing, third-party service to identify yourself (such as Google or PayPal). If you chose to do so, MyUSA will have access to the e-mail address you provide directly to MyUSA, or, possibly, indirectly via the third-party service. Unless you explicitly state otherwise, this pseudo-anonymous information will remain private to your account, and will only be used for notification and to simplify the process of retrieving your account on subsequent uses of the MyUSA Service.</p>
+<h2 id="profile-information">Profile information</h2>
+<p>The Service offers the opportunity to store personally identifiable information (such as your name or address). We want you to feel comfortable trusting MyUSA with this basic profile information. Storing such information allows MyUSA to better customize many common tasks, such as pre-filling common fields across multiple forms. This information will remain private to your account, and will only be shared with government agencies if you explicitly grant permission on a case-by-case basis or where required by law. You may delete your personal information at any time.</p>
+<h2 id="prohibition-on-use-of-personal-information">Prohibition on use of personal information</h2>
+<p>You take your privacy seriously, and so do we. At no time will your profile or login information (the information you provide voluntarily) be used without your explicit permission (except where required by law) or combined with the automatically collected, anonymous information, or otherwise used to identify or track your individual use of the Service.</p>
+<h2 id="how-information-is-used">How information is used</h2>
+<p>The information we collect is used to improve our service such as providing you with a more customized or simpler experience. We make every effort to disclose clearly how information is used at the point where it is collected so that you can determine for yourself whether you wish to provide the information.</p>
+<h2 id="sharing-and-disclosure">Sharing and disclosure</h2>
+<p>The information you give us is kept private, and is not shared with anyone, other than with your explicit permission, or as required by law. For more details on how we may share your information, please read our <a href="http://www.gpo.gov/fdsys/pkg/FR-2013-07-05/pdf/2013-16124.pdf">System of Records Notice</a>.</p>
+<h2 id="retention-of-information">Retention of information</h2>
+<p>We destroy the information we collect when the purpose for which it was provided has been fulfilled, unless we are required to keep it longer by statute or official policy. Electronically submitted information is maintained and destroyed according to the principles of the Federal Records Act and the regulations and records schedules approved by the National Archives and Records Administration. In some cases information submitted to us may become an agency record and therefore might be subject to a Freedom of Information Act request.</p>
+<h2 id="security">Security</h2>
+<p>For site security purposes and to ensure that this service remains available to all users, we employ software to monitor network traffic to identify unauthorized attempts to upload or change information, or otherwise cause damage.</p>
+<p>Except for authorized law enforcement investigations, no other attempts are made to identify individual users or their usage habits. Raw data logs are used for no other purposes and are scheduled for regular destruction in accordance with National Archives and Records Administration guidelines.</p>
+<p>If such monitoring reveals evidence of possible abuse or criminal activity, such evidence may be provided to appropriate law enforcement officials. Unauthorized attempts to upload or change information on this server are strictly prohibited and may be punishable under the Computer Fraud and Abuse Act of 1986 and the National Information Infrastructure Protection Act or other law.</p>
+<h2 id="cookies">Cookies</h2>
+<p>A cookie is a string of information that a website stores on a visitor’s computer, and that the visitor’s browser provides to the website each time the visitor returns. In order to provide a more streamlined experience and to track aggregate usage information, by default, we store small amounts of data on your computer. We uses cookies to help identify and track visitors, their usage of our services, and their website access preferences. We also use cookies to maintain your login session. If you wish to opt-out of this feature, you may do so by following <a href="http://www.usa.gov/optout-instructions.shtml">these instructions</a>, although due to technical limitations, you may lose the ability to access certain information or services.</p>
+<h2 id="interaction-with-children">Interaction with children</h2>
+<p>This website and its associated services is not intended to be accessed by children under the age of 18.</p>
+<h2 id="your-rights">Your rights</h2>
+<h3 id="privacy-act">Privacy Act</h3>
+<p>If any personal information you provide will be maintained in a Privacy Act system of records, you will be notified at the point of collection, as to whether providing information is mandatory or voluntary, and the effects of not providing all or any part of the requested information. Clicking a form “submit” button will constitute consent in this regard. Visit our <a href="http://www.gsa.gov/portal/content/104278">Privacy Act Web Page</a> for additional information.</p>
+<h3 id="freedom-of-information">Freedom of information</h3>
+<p>Under the Freedom of Information Act (FOIA) and the Privacy Act of 1974, to the extent applicable, you have certain rights to obtain information about you that may be in our records. For more information about the circumstances under which you can get and correct this information, visit our <a href="http://www.gsa.gov/portal/content/105305">FOIA Web Page</a>.</p>
+<h3 id="third-party-websites">Third party websites</h3>
+<p>To better engage the public in ongoing dialog, we use several third-party platforms including bit.ly, Facebook, Twitter, Disqus, GitHub, and UserVoice. When interacting with our presence on those websites, you may reveal certain personal information to us or to third parties. Except when used for the purpose of responding to a specific message or request, we will neither use nor share nor retain such data. We also do not use personal information made available by the user to these third-party sites.</p>
+<h3 id="usage-statistics">Usage statistics</h3>
+<p>This website employs Google Analytics (a service from Google, Inc.) to collect aggregate usage information. In utilizing this analytics service, we maintain our existing standards in regards to the sharing and disclosure of information, security and privacy safeguards for the data, and the data retention policy, each described above.</p>
+<p><strong>We reserve the right to modify this policy at any time.</strong></p>
+</div></div></div><div><div class="panel panel-default"><div class="panel-heading"><h3 id="linking-policy">Linking policy&nbsp;<a href="#linking-policy"><i class="fa fa-link"></i></a></h3></div><div class="panel-body"><p>MyUSA may link to websites created and maintained by other public and/or private organizations as outlined in <a href="http://www.usa.gov/About/Linking-Policy.shtml">USA.gov’s Linking Policy</a>. If you click a link to an outside website, you will leave the MyUSA site and are subject to the privacy and security policies of the owners/sponsors of the outside website.</p>
+<p>The General Services Administration (GSA) and MyUSA do not control or guarantee the accuracy, relevance, timeliness, or completeness of information contained on a linked website.</p>
+<p>GSA and MyUSA do not endorse the organizations sponsoring linked websites and we do not endorse the views they express or the products/services they offer.</p>
+<p>GSA and MyUSA cannot authorize the use of copyrighted materials contained in linked websites. Users must request such authorization from the sponsor of the linked website.</p>
+<p>GSA and MyUSA are not responsible for transmissions users receive from linked websites.</p>
+<p>GSA and MyUSA do not guarantee that outside websites comply with Section 508 (accessibility requirements) of the Rehabilitation Act.</p>
+</div></div></div><div><div class="panel panel-default"><div class="panel-heading"><h3 id="pra-statement">PRA Statement&nbsp;<a href="#pra-statement"><i class="fa fa-link"></i></a></h3></div><div class="panel-body"><h2 id="paperwork-reduction-act-statement">Paperwork Reduction Act Statement</h2>
+<p>OMB No: 3090-00XX</p>
+<p>Expires: XX/XX/XXXX</p>
+<p>Paperwork Reduction Act Statement - This information collection meets the requirements of 44 U.S.C. § 3507, as amended by section 2 of the Paperwork Reduction Act of 1995. You do not need to answer these questions unless we display a valid Office of Management and Budget (OMB) control number. The OMB control number for this collection is 3090-00XX. We estimate that it will take 15 minutes to read the instructions, gather the facts, and answer the questions. Send only comments relating to our time estimate, including suggestions for reducing this burden, or any other aspects of this collection of information to: General Services Administration, Regulatory Secretariat (MVCB), ATTN: Regulatory Secretariat/IC 3090-00XX, 1800 F Street, NW, 2nd Floor, Washington, DC 20405.</p>
+</div></div></div></div></div></div><p style="text-align: center;" class="text-muted">Generated by&nbsp;<a href="https://github.com/danielgtaylor/aglio" class="aglio">aglio</a>&nbsp;on 04 Sep 2014</p><div id="localFile" style="display: none; position: absolute; top: 0; left: 0; width: 100%; color: white; background: red; font-size: 150%; text-align: center; padding: 1em;">This page may not display correctly when opened as a local file. Instead, view it from a web server.
+
+</div></body><script src="//code.jquery.com/jquery-1.11.0.min.js"></script><script src="//netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js"></script><script>(function() {
+  if (location.protocol === 'file:') {
+    document.getElementById('localFile').style.display = 'block';
+  }
+
+}).call(this);
+</script><script>(function() {
+  $('table').addClass('table');
+
+}).call(this);
+</script></html>

--- a/public/legal.md
+++ b/public/legal.md
@@ -1,0 +1,163 @@
+FORMAT: 1A
+
+# MyUSA Legal Notices
+
+This document contains the legal notices regarding the MyUSA service.  This includes MyUSA's policies on linking, privacy, collection of information, terms of service, and security.
+
+# Group Terms of service
+
+The [General Services Administration](http://www.gsa.gov) ("GSA") develops and maintains MyUSA, a shared service that simplifies interacting with the Federal government online. MyUSA is provided "as-is" and entirely free. 
+
+## Scope
+
+MyUSA (hereafter, the “Service”) provides users with a persistent online persona to interact with government services. MyUSA is offered subject to your acceptance of the terms and conditions contained herein as well as any relevant sections of the [MyUSA Privacy Policy](#privacy-policy) (collectively, the “Agreement”). The Service is made available to individuals who are at least 18 years of age. Use of MyUSA, either by public individuals, entities, or Federal agencies, constitutes acceptance to this Agreement.
+
+Please be sure to read this Agreement carefully before using this website or its related services. If you do not agree to all the terms and conditions of this Agreement, then you may not access the website or use the services it provides.
+
+All of the services, content, documentation, code and related materials made available to you through the Service are subject to these terms. Access to or use of the Service or its content, whether directly or programmatically (e.g., via an application programming interface (API) or third-party application), constitutes acceptance to this Agreement.
+
+## Use
+You may use any MyUSA service directly or via third-party applications to store profile and related information, and to search, display, analyze, retrieve, view or otherwise “get” any information made available by the Service.
+
+If you are entering into this agreement on behalf of a company, Federal agency, or other legal entity, you represent that you have the authority to bind such entity, its affiliates and all users who access our services through your account to the Agreement, in which case the terms "you" or "your" shall refer to such entity, its affiliates and users associated with it. If you do not have such authority, or if you do not agree with the Agreement, you must not accept this Agreement and may not use the services.
+
+## Attribution
+
+While not required, when using content, data, documentation, code, and related materials from MyUSA in your own work, we ask that proper credit be given. An example citation is provided below:
+
+_Powered by [MyUSA](https://my.usa.gov)_
+
+You may use the MyUSA name or logos in order to identify the source of the content or service subject to these rules. You may not use the MyUSA name, logo, or the like to imply endorsement of any product, service, or entity, not-for-profit, commercial or otherwise. GSA will not be liable for any false statements or misrepresentations made by you or on your behalf as a result of your use of the Service.
+
+## Your account
+If you create a MyUSA account (or log in to the Service using a third-party login) or integrate MyUSA into an application, you are responsible for maintaining the security of your account or application and are fully responsible for the activities that occur any actions taken therein. You must immediately notify MyUSA of any unauthorized use of your account or breaches of security. GSA will not be liable for any acts or omissions by you, including any damages of any kind incurred as a result of such acts or omissions.
+
+## The information you submit
+The information you submit will remain private to you, unless you explicitly authorize an application or agency to use it at the time. It is your responsibility to ensure the information submitted to agencies and other government entities, by you or on your behalf, is and remains factual, complete, and accurate.
+
+## Modification or false representation of content
+You may not modify or falsely represent content accessed through the Service and still claim the source is MyUSA.
+
+## Right to limit
+Your use of the Service may be subject to certain limitations on access, calls, or use as set forth within this Agreement or otherwise provided by MyUSA. If GSA reasonably believes that you have attempted to exceed or circumvent these limits, your ability to use the Service may be permanently or temporarily blocked. GSA may monitor your use of the Service to improve the application or to insure compliance with this Agreement.
+
+## Service termination
+If you wish to terminate this Agreement, you may do so by refraining from further use of MyUSA. GSA reserves the right (though not the obligation) to refuse to provide MyUSA to you if it is GSA's opinion that use violates any GSA or Federal policy or law. GSA also reserves the right to stop providing MyUSA at any time for any reason in its sole discretion. All provisions of this Agreement, which by their nature should survive termination, shall survive termination including warranty disclaimers and limitations of liability.
+
+## Changes
+GSA reserves the right, at its sole discretion, to modify or replace this Agreement, in whole or in part. Your continued use of or access to MyUSA following posting of any changes to this Agreement constitutes acceptance of those modified terms. MyUSA may, in the future, offer new capabilities and/or features through the MyUSA. Such new features and/or capabilities shall be subject to the terms and conditions of this Agreement.
+
+## Disclaimer of warranties
+MyUSA is provided “as is” and on an “as-available” basis. GSA will do its best to ensure MyUSA is available and functional as much as possible, GSA hereby disclaim all warranties of any kind, express or implied, including without limitation the warranties of merchantability, fitness for a particular purpose, and non-infringement. GSA makes no warranty that MyUSA data will be error free or that access thereto will be continuous or uninterrupted.
+
+## Limitations on liability
+In no event will GSA be liable with respect to any subject matter of this Agreement under any contract, negligence, strict liability or other legal or equitable theory for: (1) any special, incidental, or consequential damages; (2) the cost of procurement of substitute products or services; or (3) for interruption of use or loss or corruption of data.
+
+## Miscellaneous
+This Agreement constitutes the entire Agreement between GSA and you concerning the subject matter hereof, and may only be modified by the posting of a revised version on this page by GSA.
+
+## Disputes
+Any disputes arising out of this Agreement and access to or use of the Service shall be governed by federal law.
+
+## No waiver of rights
+GSA's failure to exercise or enforce any right or provision of this Agreement shall not constitute waiver of such right or provision.
+
+## Security
+If you represent a Federal agency and would like to understand the [risk management framework](http://csrc.nist.gov/groups/SMA/fisma/framework.html) of MyUSA under the Federal Information Security Management Act, please email GSA@gsa.gov with the subject line _MyUSA FISMA Status_.
+
+# Group Privacy policy
+
+We hold your privacy in the highest regard. MyUSA collects some anonymous information automatically to help us improve the service (such as what parts of our system are being used when). MyUSA also gives you an option to provide basic personal information, which we’ll use to customize your experience and simplify many common tasks. MyUSA has a few fundamental principles:
+
+1. Your personal information will only be used to improve or customize your experience.
+1. The information you provide is your information and you have the ultimate say in how it’s used.
+1. We’ll always ask before we share your information with an agency or other government entity, and unless you say otherwise, it will remain private to you (except where required by law, as detailed in our [System of Records Notice](http://www.gpo.gov/fdsys/pkg/FR-2013-07-05/pdf/2013-16124.pdf)).
+1. We never store personal information on our servers unless required for the on-going operation of one of our services.
+
+## Generally
+We are committed to protecting the privacy of our users. We collect no personal information unless you choose to provide that information to us.
+
+## Information collected automatically
+Like most website operators, as you use our service, either directly or indirectly, we may collect and store the following non-personally-identifiable (a.k.a. anonymous) information about your visit:
+
+- the date and time you access MyUSA;
+- the various components of MyUSA you access;
+- if you access the MyUSA from another website or application - the identity of that third-party;
+- the technical capabilities of the computer you use to access our site, and
+- the IP address (an anonymous number automatically assigned to your computer whenever you are surfing the internet) from which you access MyUSA.
+
+We use this information, in the aggregate, to make MyUSA more useful to users — to learn about the number of and type of users of MyUSA, the components utilized, the types of technology used, to detect operational problems, and to improve MyUSA’s overall security.
+
+## Information that you provide voluntarily
+Certain users of our service choose to interact with it in ways that require us to gather personally-identifying information. The amount and type of information that we gather depends on the nature of the interaction. For example, if you add your name and street address to your MyUSA profile, we may offer to pre-fill common fields as you complete a form. In each case, we collect such information only insofar as is necessary or appropriate to fulfill the purpose of the user’s interaction with us. We do not disclose personally-identifying information other than as described in our [System of Records Notice](http://www.gpo.gov/fdsys/pkg/FR-2013-07-05/pdf/2013-16124.pdf). Users may refuse to supply personally-identifying information at any time, with the understanding that it may prevent them from engaging in certain website-related activities.
+
+## Login information
+When using our Service, you may be prompted with the opportunity to create a MyUSA account, or use an existing, third-party service to identify yourself (such as Google or PayPal). If you chose to do so, MyUSA will have access to the e-mail address you provide directly to MyUSA, or, possibly, indirectly via the third-party service. Unless you explicitly state otherwise, this pseudo-anonymous information will remain private to your account, and will only be used for notification and to simplify the process of retrieving your account on subsequent uses of the MyUSA Service.
+
+## Profile information
+The Service offers the opportunity to store personally identifiable information (such as your name or address). We want you to feel comfortable trusting MyUSA with this basic profile information. Storing such information allows MyUSA to better customize many common tasks, such as pre-filling common fields across multiple forms. This information will remain private to your account, and will only be shared with government agencies if you explicitly grant permission on a case-by-case basis or where required by law. You may delete your personal information at any time.
+
+## Prohibition on use of personal information
+You take your privacy seriously, and so do we. At no time will your profile or login information (the information you provide voluntarily) be used without your explicit permission (except where required by law) or combined with the automatically collected, anonymous information, or otherwise used to identify or track your individual use of the Service.
+
+## How information is used
+The information we collect is used to improve our service such as providing you with a more customized or simpler experience. We make every effort to disclose clearly how information is used at the point where it is collected so that you can determine for yourself whether you wish to provide the information.
+
+## Sharing and disclosure
+The information you give us is kept private, and is not shared with anyone, other than with your explicit permission, or as required by law. For more details on how we may share your information, please read our [System of Records Notice](http://www.gpo.gov/fdsys/pkg/FR-2013-07-05/pdf/2013-16124.pdf).
+
+## Retention of information
+We destroy the information we collect when the purpose for which it was provided has been fulfilled, unless we are required to keep it longer by statute or official policy. Electronically submitted information is maintained and destroyed according to the principles of the Federal Records Act and the regulations and records schedules approved by the National Archives and Records Administration. In some cases information submitted to us may become an agency record and therefore might be subject to a Freedom of Information Act request.
+
+## Security
+For site security purposes and to ensure that this service remains available to all users, we employ software to monitor network traffic to identify unauthorized attempts to upload or change information, or otherwise cause damage.
+
+Except for authorized law enforcement investigations, no other attempts are made to identify individual users or their usage habits. Raw data logs are used for no other purposes and are scheduled for regular destruction in accordance with National Archives and Records Administration guidelines.
+
+If such monitoring reveals evidence of possible abuse or criminal activity, such evidence may be provided to appropriate law enforcement officials. Unauthorized attempts to upload or change information on this server are strictly prohibited and may be punishable under the Computer Fraud and Abuse Act of 1986 and the National Information Infrastructure Protection Act or other law.
+
+## Cookies
+A cookie is a string of information that a website stores on a visitor’s computer, and that the visitor’s browser provides to the website each time the visitor returns. In order to provide a more streamlined experience and to track aggregate usage information, by default, we store small amounts of data on your computer. We uses cookies to help identify and track visitors, their usage of our services, and their website access preferences. We also use cookies to maintain your login session. If you wish to opt-out of this feature, you may do so by following [these instructions](http://www.usa.gov/optout-instructions.shtml), although due to technical limitations, you may lose the ability to access certain information or services.
+
+## Interaction with children
+This website and its associated services is not intended to be accessed by children under the age of 18.
+
+## Your rights
+
+### Privacy Act
+If any personal information you provide will be maintained in a Privacy Act system of records, you will be notified at the point of collection, as to whether providing information is mandatory or voluntary, and the effects of not providing all or any part of the requested information. Clicking a form “submit” button will constitute consent in this regard. Visit our [Privacy Act Web Page](http://www.gsa.gov/portal/content/104278) for additional information.
+
+### Freedom of information
+Under the Freedom of Information Act (FOIA) and the Privacy Act of 1974, to the extent applicable, you have certain rights to obtain information about you that may be in our records. For more information about the circumstances under which you can get and correct this information, visit our [FOIA Web Page](http://www.gsa.gov/portal/content/105305).
+
+### Third party websites
+To better engage the public in ongoing dialog, we use several third-party platforms including bit.ly, Facebook, Twitter, Disqus, GitHub, and UserVoice. When interacting with our presence on those websites, you may reveal certain personal information to us or to third parties. Except when used for the purpose of responding to a specific message or request, we will neither use nor share nor retain such data. We also do not use personal information made available by the user to these third-party sites.
+
+### Usage statistics
+This website employs Google Analytics (a service from Google, Inc.) to collect aggregate usage information. In utilizing this analytics service, we maintain our existing standards in regards to the sharing and disclosure of information, security and privacy safeguards for the data, and the data retention policy, each described above.
+
+**We reserve the right to modify this policy at any time.**
+
+# Group Linking policy
+
+MyUSA may link to websites created and maintained by other public and/or private organizations as outlined in [USA.gov’s Linking Policy](http://www.usa.gov/About/Linking-Policy.shtml). If you click a link to an outside website, you will leave the MyUSA site and are subject to the privacy and security policies of the owners/sponsors of the outside website.
+
+The General Services Administration (GSA) and MyUSA do not control or guarantee the accuracy, relevance, timeliness, or completeness of information contained on a linked website.
+
+GSA and MyUSA do not endorse the organizations sponsoring linked websites and we do not endorse the views they express or the products/services they offer.
+
+GSA and MyUSA cannot authorize the use of copyrighted materials contained in linked websites. Users must request such authorization from the sponsor of the linked website.
+
+GSA and MyUSA are not responsible for transmissions users receive from linked websites.
+
+GSA and MyUSA do not guarantee that outside websites comply with Section 508 (accessibility requirements) of the Rehabilitation Act.
+
+# Group PRA Statement
+
+## Paperwork Reduction Act Statement
+
+OMB No: 3090-00XX
+
+Expires: XX/XX/XXXX
+
+Paperwork Reduction Act Statement - This information collection meets the requirements of 44 U.S.C. § 3507, as amended by section 2 of the Paperwork Reduction Act of 1995. You do not need to answer these questions unless we display a valid Office of Management and Budget (OMB) control number. The OMB control number for this collection is 3090-00XX. We estimate that it will take 15 minutes to read the instructions, gather the facts, and answer the questions. Send only comments relating to our time estimate, including suggestions for reducing this burden, or any other aspects of this collection of information to: General Services Administration, Regulatory Secretariat (MVCB), ATTN: Regulatory Secretariat/IC 3090-00XX, 1800 F Street, NW, 2nd Floor, Washington, DC 20405.

--- a/public/legal/linking.md
+++ b/public/legal/linking.md
@@ -1,0 +1,14 @@
+
+# Group Linking policy
+
+MyUSA may link to websites created and maintained by other public and/or private organizations as outlined in [USA.gov’s Linking Policy](http://www.usa.gov/About/Linking-Policy.shtml). If you click a link to an outside website, you will leave the MyUSA site and are subject to the privacy and security policies of the owners/sponsors of the outside website.
+
+The General Services Administration (GSA) and MyUSA do not control or guarantee the accuracy, relevance, timeliness, or completeness of information contained on a linked website.
+
+GSA and MyUSA do not endorse the organizations sponsoring linked websites and we do not endorse the views they express or the products/services they offer.
+
+GSA and MyUSA cannot authorize the use of copyrighted materials contained in linked websites. Users must request such authorization from the sponsor of the linked website.
+
+GSA and MyUSA are not responsible for transmissions users receive from linked websites.
+
+GSA and MyUSA do not guarantee that outside websites comply with Section 508 (accessibility requirements) of the Rehabilitation Act.

--- a/public/legal/overview.md
+++ b/public/legal/overview.md
@@ -1,0 +1,5 @@
+FORMAT: 1A
+
+# MyUSA Legal Notices
+
+This document contains the legal notices regarding the MyUSA service.  This includes MyUSA's policies on linking, privacy, collection of information, terms of service, and security.

--- a/public/legal/pra.md
+++ b/public/legal/pra.md
@@ -1,0 +1,10 @@
+
+# Group PRA Statement
+
+## Paperwork Reduction Act Statement
+
+OMB No: 3090-00XX
+
+Expires: XX/XX/XXXX
+
+Paperwork Reduction Act Statement - This information collection meets the requirements of 44 U.S.C. § 3507, as amended by section 2 of the Paperwork Reduction Act of 1995. You do not need to answer these questions unless we display a valid Office of Management and Budget (OMB) control number. The OMB control number for this collection is 3090-00XX. We estimate that it will take 15 minutes to read the instructions, gather the facts, and answer the questions. Send only comments relating to our time estimate, including suggestions for reducing this burden, or any other aspects of this collection of information to: General Services Administration, Regulatory Secretariat (MVCB), ATTN: Regulatory Secretariat/IC 3090-00XX, 1800 F Street, NW, 2nd Floor, Washington, DC 20405.

--- a/public/legal/privacy.md
+++ b/public/legal/privacy.md
@@ -1,0 +1,73 @@
+
+# Group Privacy policy
+
+We hold your privacy in the highest regard. MyUSA collects some anonymous information automatically to help us improve the service (such as what parts of our system are being used when). MyUSA also gives you an option to provide basic personal information, which we’ll use to customize your experience and simplify many common tasks. MyUSA has a few fundamental principles:
+
+1. Your personal information will only be used to improve or customize your experience.
+1. The information you provide is your information and you have the ultimate say in how it’s used.
+1. We’ll always ask before we share your information with an agency or other government entity, and unless you say otherwise, it will remain private to you (except where required by law, as detailed in our [System of Records Notice](http://www.gpo.gov/fdsys/pkg/FR-2013-07-05/pdf/2013-16124.pdf)).
+1. We never store personal information on our servers unless required for the on-going operation of one of our services.
+
+## Generally
+We are committed to protecting the privacy of our users. We collect no personal information unless you choose to provide that information to us.  An assessment of the privacy impact of MyUSA is in our [Privacy Impact Assessment](http://www.gsa.gov/portal/getMediaData?mediaId=180583).
+
+## Information collected automatically
+Like most website operators, as you use our service, either directly or indirectly, we may collect and store the following non-personally-identifiable (a.k.a. anonymous) information about your visit:
+
+- the date and time you access MyUSA;
+- the various components of MyUSA you access;
+- if you access the MyUSA from another website or application - the identity of that third-party;
+- the technical capabilities of the computer you use to access our site, and
+- the IP address (an anonymous number automatically assigned to your computer whenever you are surfing the internet) from which you access MyUSA.
+
+We use this information, in the aggregate, to make MyUSA more useful to users — to learn about the number of and type of users of MyUSA, the components utilized, the types of technology used, to detect operational problems, and to improve MyUSA’s overall security.
+
+## Information that you provide voluntarily
+Certain users of our service choose to interact with it in ways that require us to gather personally-identifying information. The amount and type of information that we gather depends on the nature of the interaction. For example, if you add your name and street address to your MyUSA profile, we may offer to pre-fill common fields as you complete a form. In each case, we collect such information only insofar as is necessary or appropriate to fulfill the purpose of the user’s interaction with us. We do not disclose personally-identifying information other than as described in our [System of Records Notice](http://www.gpo.gov/fdsys/pkg/FR-2013-07-05/pdf/2013-16124.pdf). Users may refuse to supply personally-identifying information at any time, with the understanding that it may prevent them from engaging in certain website-related activities.
+
+## Login information
+When using our Service, you may be prompted with the opportunity to create a MyUSA account, or use an existing, third-party service to identify yourself (such as Google or PayPal). If you chose to do so, MyUSA will have access to the e-mail address you provide directly to MyUSA, or, possibly, indirectly via the third-party service. Unless you explicitly state otherwise, this pseudo-anonymous information will remain private to your account, and will only be used for notification and to simplify the process of retrieving your account on subsequent uses of the MyUSA Service.
+
+## Profile information
+The Service offers the opportunity to store personally identifiable information (such as your name or address). We want you to feel comfortable trusting MyUSA with this basic profile information. Storing such information allows MyUSA to better customize many common tasks, such as pre-filling common fields across multiple forms. This information will remain private to your account, and will only be shared with government agencies if you explicitly grant permission on a case-by-case basis or where required by law. You may delete your personal information at any time.
+
+## Prohibition on use of personal information
+You take your privacy seriously, and so do we. At no time will your profile or login information (the information you provide voluntarily) be used without your explicit permission (except where required by law) or combined with the automatically collected, anonymous information, or otherwise used to identify or track your individual use of the Service.
+
+## How information is used
+The information we collect is used to improve our service such as providing you with a more customized or simpler experience. We make every effort to disclose clearly how information is used at the point where it is collected so that you can determine for yourself whether you wish to provide the information.
+
+## Sharing and disclosure
+The information you give us is kept private, and is not shared with anyone, other than with your explicit permission, or as required by law. For more details on how we may share your information, please read our [System of Records Notice](http://www.gpo.gov/fdsys/pkg/FR-2013-07-05/pdf/2013-16124.pdf).
+
+## Retention of information
+We destroy the information we collect when the purpose for which it was provided has been fulfilled, unless we are required to keep it longer by statute or official policy. Electronically submitted information is maintained and destroyed according to the principles of the Federal Records Act and the regulations and records schedules approved by the National Archives and Records Administration. In some cases information submitted to us may become an agency record and therefore might be subject to a Freedom of Information Act request.
+
+## Security
+For site security purposes and to ensure that this service remains available to all users, we employ software to monitor network traffic to identify unauthorized attempts to upload or change information, or otherwise cause damage.
+
+Except for authorized law enforcement investigations, no other attempts are made to identify individual users or their usage habits. Raw data logs are used for no other purposes and are scheduled for regular destruction in accordance with National Archives and Records Administration guidelines.
+
+If such monitoring reveals evidence of possible abuse or criminal activity, such evidence may be provided to appropriate law enforcement officials. Unauthorized attempts to upload or change information on this server are strictly prohibited and may be punishable under the Computer Fraud and Abuse Act of 1986 and the National Information Infrastructure Protection Act or other law.
+
+## Cookies
+A cookie is a string of information that a website stores on a visitor’s computer, and that the visitor’s browser provides to the website each time the visitor returns. In order to provide a more streamlined experience and to track aggregate usage information, by default, we store small amounts of data on your computer. We uses cookies to help identify and track visitors, their usage of our services, and their website access preferences. We also use cookies to maintain your login session. If you wish to opt-out of this feature, you may do so by following [these instructions](http://www.usa.gov/optout-instructions.shtml), although due to technical limitations, you may lose the ability to access certain information or services.
+
+## Interaction with children
+This website and its associated services is not intended to be accessed by children under the age of 18.
+
+## Your rights
+
+### Privacy Act
+If any personal information you provide will be maintained in a Privacy Act system of records, you will be notified at the point of collection, as to whether providing information is mandatory or voluntary, and the effects of not providing all or any part of the requested information. Clicking a form “submit” button will constitute consent in this regard. Visit our [Privacy Act Web Page](http://www.gsa.gov/portal/content/104278) for additional information.
+
+### Freedom of information
+Under the Freedom of Information Act (FOIA) and the Privacy Act of 1974, to the extent applicable, you have certain rights to obtain information about you that may be in our records. For more information about the circumstances under which you can get and correct this information, visit our [FOIA Web Page](http://www.gsa.gov/portal/content/105305).
+
+### Third party websites
+To better engage the public in ongoing dialog, we use several third-party platforms including bit.ly, Facebook, Twitter, Disqus, GitHub, and UserVoice. When interacting with our presence on those websites, you may reveal certain personal information to us or to third parties. Except when used for the purpose of responding to a specific message or request, we will neither use nor share nor retain such data. We also do not use personal information made available by the user to these third-party sites.
+
+### Usage statistics
+This website employs Google Analytics (a service from Google, Inc.) to collect aggregate usage information. In utilizing this analytics service, we maintain our existing standards in regards to the sharing and disclosure of information, security and privacy safeguards for the data, and the data retention policy, each described above.
+
+**We reserve the right to modify this policy at any time.**

--- a/public/legal/terms.md
+++ b/public/legal/terms.md
@@ -1,0 +1,61 @@
+
+# Group Terms of service
+
+The [General Services Administration](http://www.gsa.gov) ("GSA") develops and maintains MyUSA, a shared service that simplifies interacting with the Federal government online. MyUSA is provided "as-is" and entirely free. 
+
+## Scope
+
+MyUSA (hereafter, the “Service”) provides users with a persistent online persona to interact with government services. MyUSA is offered subject to your acceptance of the terms and conditions contained herein as well as any relevant sections of the [MyUSA Privacy Policy](#privacy-policy) (collectively, the “Agreement”). The Service is made available to individuals who are at least 18 years of age. Use of MyUSA, either by public individuals, entities, or Federal agencies, constitutes acceptance to this Agreement.
+
+Please be sure to read this Agreement carefully before using this website or its related services. If you do not agree to all the terms and conditions of this Agreement, then you may not access the website or use the services it provides.
+
+All of the services, content, documentation, code and related materials made available to you through the Service are subject to these terms. Access to or use of the Service or its content, whether directly or programmatically (e.g., via an application programming interface (API) or third-party application), constitutes acceptance to this Agreement.
+
+## Use
+You may use any MyUSA service directly or via third-party applications to store profile and related information, and to search, display, analyze, retrieve, view or otherwise “get” any information made available by the Service.
+
+If you are entering into this agreement on behalf of a company, Federal agency, or other legal entity, you represent that you have the authority to bind such entity, its affiliates and all users who access our services through your account to the Agreement, in which case the terms "you" or "your" shall refer to such entity, its affiliates and users associated with it. If you do not have such authority, or if you do not agree with the Agreement, you must not accept this Agreement and may not use the services.
+
+## Attribution
+
+While not required, when using content, data, documentation, code, and related materials from MyUSA in your own work, we ask that proper credit be given. An example citation is provided below:
+
+_Powered by [MyUSA](https://my.usa.gov)_
+
+You may use the MyUSA name or logos in order to identify the source of the content or service subject to these rules. You may not use the MyUSA name, logo, or the like to imply endorsement of any product, service, or entity, not-for-profit, commercial or otherwise. GSA will not be liable for any false statements or misrepresentations made by you or on your behalf as a result of your use of the Service.
+
+## Your account
+If you create a MyUSA account (or log in to the Service using a third-party login) or integrate MyUSA into an application, you are responsible for maintaining the security of your account or application and are fully responsible for the activities that occur any actions taken therein. You must immediately notify MyUSA of any unauthorized use of your account or breaches of security. GSA will not be liable for any acts or omissions by you, including any damages of any kind incurred as a result of such acts or omissions.
+
+## The information you submit
+The information you submit will remain private to you, unless you explicitly authorize an application or agency to use it at the time. It is your responsibility to ensure the information submitted to agencies and other government entities, by you or on your behalf, is and remains factual, complete, and accurate.
+
+## Modification or false representation of content
+You may not modify or falsely represent content accessed through the Service and still claim the source is MyUSA.
+
+## Right to limit
+Your use of the Service may be subject to certain limitations on access, calls, or use as set forth within this Agreement or otherwise provided by MyUSA. If GSA reasonably believes that you have attempted to exceed or circumvent these limits, your ability to use the Service may be permanently or temporarily blocked. GSA may monitor your use of the Service to improve the application or to insure compliance with this Agreement.
+
+## Service termination
+If you wish to terminate this Agreement, you may do so by refraining from further use of MyUSA. GSA reserves the right (though not the obligation) to refuse to provide MyUSA to you if it is GSA's opinion that use violates any GSA or Federal policy or law. GSA also reserves the right to stop providing MyUSA at any time for any reason in its sole discretion. All provisions of this Agreement, which by their nature should survive termination, shall survive termination including warranty disclaimers and limitations of liability.
+
+## Changes
+GSA reserves the right, at its sole discretion, to modify or replace this Agreement, in whole or in part. Your continued use of or access to MyUSA following posting of any changes to this Agreement constitutes acceptance of those modified terms. MyUSA may, in the future, offer new capabilities and/or features through the MyUSA. Such new features and/or capabilities shall be subject to the terms and conditions of this Agreement.
+
+## Disclaimer of warranties
+MyUSA is provided “as is” and on an “as-available” basis. GSA will do its best to ensure MyUSA is available and functional as much as possible, GSA hereby disclaim all warranties of any kind, express or implied, including without limitation the warranties of merchantability, fitness for a particular purpose, and non-infringement. GSA makes no warranty that MyUSA data will be error free or that access thereto will be continuous or uninterrupted.
+
+## Limitations on liability
+In no event will GSA be liable with respect to any subject matter of this Agreement under any contract, negligence, strict liability or other legal or equitable theory for: (1) any special, incidental, or consequential damages; (2) the cost of procurement of substitute products or services; or (3) for interruption of use or loss or corruption of data.
+
+## Miscellaneous
+This Agreement constitutes the entire Agreement between GSA and you concerning the subject matter hereof, and may only be modified by the posting of a revised version on this page by GSA.
+
+## Disputes
+Any disputes arising out of this Agreement and access to or use of the Service shall be governed by federal law.
+
+## No waiver of rights
+GSA's failure to exercise or enforce any right or provision of this Agreement shall not constitute waiver of such right or provision.
+
+## Security
+If you represent a Federal agency and would like to understand the [risk management framework](http://csrc.nist.gov/groups/SMA/fisma/framework.html) of MyUSA under the Federal Information Security Management Act, please email GSA@gsa.gov with the subject line _MyUSA FISMA Status_.


### PR DESCRIPTION
This addresses #49 and #108.  It posts the legal docs
as markdown, and then processes them into one legal.md file
using a rake task.  From there, aglio turns the markdown
into html, and puts it in /public/legal.html.
