### PR TITLE
Flash message no longer says 'true'

### DIFF
--- a/app/views/layouts/_messages.html.erb
+++ b/app/views/layouts/_messages.html.erb
@@ -1,4 +1,5 @@
 <% flash.each do |key, value| %>
+  <% next if key.to_s == 'timedout' %>
   <div class="alert alert-<%=standard_flash(key)%>">
     <a href="#" data-dismiss="alert" class="close">×</a>
     	<%= value %>


### PR DESCRIPTION
This fixes #215 so that a `true` flash message is no longer displayed.
