### PR TITLE
Responsive spacing issues; section centering

### DIFF
--- a/app/assets/stylesheets/partials/_bootstrap-overrides.css.scss
+++ b/app/assets/stylesheets/partials/_bootstrap-overrides.css.scss
@@ -70,3 +70,10 @@ ul.dropdown-menu {
   background-color: transparent;
   font-weight: 700;
 }
+
+/**
+ * needed for the column to actually float in the center of the layout
+ */
+.center-block {
+  float: none;
+}

--- a/app/assets/stylesheets/partials/_myusa.css.scss
+++ b/app/assets/stylesheets/partials/_myusa.css.scss
@@ -408,12 +408,12 @@ footer {
       @media (min-width: $screen-md-min) {
         font-family: 'FontAwesome';
         content: "\f105";
-        font-size: 300px;
+        font-size: 150px;
         color: #666;
-        opacity: 0.075;
+        opacity: 0.15;
         position: absolute;
-        top: -100px;
-        right: -100px;
+        top: -65px;
+        right: -40px;
       }
     }
   }

--- a/app/views/devise/sessions/_login.html.erb
+++ b/app/views/devise/sessions/_login.html.erb
@@ -1,5 +1,5 @@
 <div class="row">
-<div class="col-md-10 col-md-offset-1">
+<div class="col-sm-10 col-md-8 col-lg-7 center-block">
 <div class="login callout-box">
   <div class="shield">
     <i class="fa icon-myusa"></i>

--- a/app/views/marketing/_for_developers.html.erb
+++ b/app/views/marketing/_for_developers.html.erb
@@ -8,7 +8,7 @@
       </div>
     </div>
     <div class="row">
-      <div class="col-sm-4 col-md-3 text-center numbered-step">
+      <div class="col-sm-4 col-md-4 text-center numbered-step">
         <div>
           <span class="fa-stack fa-3x">
             <i class="fa fa-circle fa-stack-2x"></i>
@@ -25,8 +25,7 @@
           <%= link_to "Get Started", new_user_session_path, :target => "_new", :class => "btn btn-primary width-80" %>
         </p>
       </div>
-      <div class="col-md-1"></div>
-      <div class="col-sm-4 col-md-3 text-center numbered-step">
+      <div class="col-sm-4 col-md-4 text-center numbered-step">
         <div>
           <span class="fa-stack fa-3x">
             <i class="fa fa-circle fa-stack-2x"></i>
@@ -43,8 +42,7 @@
           <%= link_to "Learn How", '/faq', :target => "_new", :class => "btn btn-primary width-80" %>
         </p>
       </div>
-      <div class="col-md-1"></div>
-      <div class="col-sm-4 col-md-3 text-center numbered-step">
+      <div class="col-sm-4 col-md-4 text-center numbered-step">
         <div>
           <span class="fa-stack fa-3x">
             <i class="fa fa-circle fa-stack-2x"></i>


### PR DESCRIPTION
Reduced the arrows in the steps and put them near the numbers. This is instead of the big arrows. Centered the section with the numbers using bootstrap columns.

Made the width of the login block constrained across different screen resolutions, and used the bootstrap center-block option to center it on the page.

Changes requested by @dutchashell, who has reviewed and approves.
