### PR TITLE
Remove bootstrap column classes for logo url field

### DIFF
--- a/app/views/doorkeeper/applications/_form.html.erb
+++ b/app/views/doorkeeper/applications/_form.html.erb
@@ -51,11 +51,9 @@
   <% end %>
 
   <%= content_tag :div, class: "form-group#{' has-error' if application.errors[:logo_url].present?}" do %>
-    <div class="col-md-10 col-md-offset-2">
-      <%= f.label :logo_url, class: ' control-label', for: 'application_logo_url' %>
-      <%= f.text_field :logo_url, class: 'form-control' %>
-      <%= doorkeeper_errors_for application, :logo_url %>
-    </div>
+    <%= f.label :logo_url, class: ' control-label', for: 'application_logo_url' %>
+    <%= f.text_field :logo_url, class: 'form-control' %>
+    <%= doorkeeper_errors_for application, :logo_url %>
   <% end %>
 
   <%= content_tag :div, class: "form-group#{' has-error' if application.errors[:custom_text].present?}" do %>


### PR DESCRIPTION
These shouldn't have been in the PR and were missed.  Quick fix.
