### PR TITLE
Provide a different message for logged in users

### DIFF
--- a/app/assets/stylesheets/partials/_myusa.css.scss
+++ b/app/assets/stylesheets/partials/_myusa.css.scss
@@ -300,6 +300,7 @@ footer {
   .callout-box{
     margin-top: 20px;
     opacity: 0.8;
+    min-height: 300px;
   }
   .login {
     margin-left: 15px;
@@ -312,6 +313,17 @@ footer {
     .shield {
       .icon-myusa {
         color: $blue-lightest;
+      }
+    }
+    &.logged-in {
+      h2 {
+        font-size: 1.4em;
+        padding-top: 20px;
+        padding-bottom: 10px;
+      }
+      .btn-lg {
+        margin-top: 5px;
+        margin-bottom: 15px;
       }
     }
     .omniauth-buttons {

--- a/app/views/devise/sessions/_email_option.html.erb
+++ b/app/views/devise/sessions/_email_option.html.erb
@@ -1,5 +1,5 @@
 <div class="row">
-  <div class="col-sm-10 col-sm-offset-1 col-md-8 col-md-offset-2 col-lg-6 col-lg-offset-3">
+  <div class="col-sm-10 col-sm-offset-1">
     <%= form_for(resource, as: resource_name, url: session_path(resource_name), html: { role: "form" }) do |f| %>
       <div class="form-group">
         <%= label_tag 'inputEmail', "Enter your Email Address", class: 'blue_header' %>

--- a/app/views/devise/sessions/_login.html.erb
+++ b/app/views/devise/sessions/_login.html.erb
@@ -1,9 +1,41 @@
 <div class="row">
 <div class="col-sm-10 col-md-8 col-lg-7 center-block">
-<div class="login callout-box">
+<div class="login callout-box <% if user_signed_in? %>logged-in<% end %>">
   <div class="shield">
     <i class="fa icon-myusa"></i>
   </div>
+
+  <% if user_signed_in? %>
+
+  <div class="row">
+    <div class="col-md-12">
+      <h1 class="text-center">
+        Welcome to MyUSA<% if current_user.profile.first_name %>, <%= current_user.profile.first_name %><% end %>
+      </h1>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-md-12">
+      <h2 class="text-center">
+        Here's a few ways to get started with MyUSA.
+      </h2>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-md-5 col-md-offset-1">
+      <button class="btn btn-primary btn-lg width-100">
+        My Profile
+      </button>
+    </div>
+    <div class="col-md-5">
+      <button class="btn btn-primary btn-lg width-100">
+        My Applications
+      </button>
+    </div>
+  </div>
+
+  <% else %>
+
   <div class="row">
     <div class="col-md-12">
       <h1 class="text-center">
@@ -49,5 +81,7 @@
       </span>
     </div>
   </div>
+
+  <% end %>
 </div>
 </div></div>


### PR DESCRIPTION
When viewing the homepage after logging in, it asks you to log in again.  Now that doesn't make much sense.  Instead, let people go to their profile or applications.

This is a temporary change until the rest of the dashboard app is built out, but provides a better experience than we had before and is "good enough" for testing.

@dutchashell reviewed and is ok with this.
