### PR TITLE
Audit User destroy

### DIFF
--- a/app/models/authentication.rb
+++ b/app/models/authentication.rb
@@ -1,4 +1,4 @@
 class Authentication < ActiveRecord::Base
   belongs_to :user
-  audit_on :create
+  audit_on :after_create
 end

--- a/app/models/authentication_token.rb
+++ b/app/models/authentication_token.rb
@@ -1,7 +1,8 @@
 class AuthenticationToken < ActiveRecord::Base
   belongs_to :user
 
-  audit_on :create
+  audit_on :after_create
+  
   before_create {|t| t.sent_at = Time.now }
 
   default_scope -> { where(['sent_at > ?', Time.now - 2.hours]) }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -23,6 +23,8 @@ class User < ActiveRecord::Base
   before_validation :generate_uid
   before_create :build_default_profile
 
+  audit_on :before_destroy
+
   devise :omniauthable, :email_authenticatable, :rememberable, :timeoutable
 
   attr_accessor :just_created, :auto_approve

--- a/lib/audit/user_action.rb
+++ b/lib/audit/user_action.rb
@@ -8,9 +8,8 @@ module Audit
         wrapper_opts = opts.slice(:action)
 
         audit_wrapper = Wrapper.new(opts)
-        hooks = events.map {|e| "after_#{e}".to_sym }
 
-        hooks.each {|h| send h, audit_wrapper, callback_opts }
+        events.each {|e| send e, audit_wrapper, callback_opts }
       end
     end
 
@@ -44,6 +43,10 @@ module Audit
 
       def after_update(record)
         audit(@action || 'update', record)
+      end
+
+      def before_destroy(record)
+        audit(@action || 'destroy', record)
       end
 
       private

--- a/lib/doorkeeper_patches/models/access_grant.rb
+++ b/lib/doorkeeper_patches/models/access_grant.rb
@@ -1,4 +1,4 @@
 class Doorkeeper::AccessGrant
   belongs_to :resource_owner, class_name: User
-  audit_on :create, action: 'grant'
+  audit_on :after_create, action: 'grant'
 end

--- a/lib/doorkeeper_patches/models/access_token.rb
+++ b/lib/doorkeeper_patches/models/access_token.rb
@@ -1,5 +1,5 @@
 class Doorkeeper::AccessToken
   belongs_to :resource_owner, class_name: User
-  audit_on :create, action: 'issue'
-  audit_on :update, action: 'revoke', if: -> { revoked_at_changed? && revoked_at_was.nil? }
+  audit_on :after_create, action: 'issue'
+  audit_on :after_update, action: 'revoke', if: -> { revoked_at_changed? && revoked_at_was.nil? }
 end

--- a/lib/doorkeeper_patches/models/application.rb
+++ b/lib/doorkeeper_patches/models/application.rb
@@ -17,6 +17,6 @@ class Doorkeeper::Application
     end
   end
 
-  audit_on :create
+  audit_on :after_create
 
 end

--- a/spec/lib/audit_spec.rb
+++ b/spec/lib/audit_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 module Audit
   describe ApplicationController, type: :controller do
     class Dummy < ActiveRecord::Base
-      audit_on :create
+      audit_on :after_create
     end
 
     before :all do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -48,6 +48,9 @@ describe User, type: :model do
       it 'deletes application' do
         is_expected.to change { Doorkeeper::Application.count }.by(-1)
       end
+      it 'creates delete user action' do
+        is_expected.to change(UserAction.where(action: 'destroy'), :count).by(1)
+      end
     end
   end
 


### PR DESCRIPTION
Changed the way audit_on works (send actual callback name) b/c there is no after_destroy-- only a before_destroy.
