### PR TITLE
Fix "For Agencies" link - #380

### DIFF
--- a/app/views/layouts/_header_mkt.html.erb
+++ b/app/views/layouts/_header_mkt.html.erb
@@ -20,7 +20,7 @@
           <%= link_to 'Home', root_path %>
         </li>
         <li>
-          <%= link_to 'For Agencies', '#agencies' %>
+          <%= link_to 'For Agencies', '/#agencies' %>
         </li>
         <li>
           <%= link_to 'For Developers', '/developer' %>


### PR DESCRIPTION
The for agencies content is on the front page, so change the url to include the leading `/`

Fixes #380.
