### PR TITLE
factor out roles helper into module

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -50,30 +50,4 @@ class ApplicationController < ActionController::Base
     super(resource_or_scope)
   end
 
-  def require_owner_or_admin!
-    require_owner!
-  rescue Acl9::AccessDenied => e
-    require_admin!
-  end
-
-  def require_owner!
-    authenticate_user!
-    current_user.has_role_for?(resource) or raise Acl9::AccessDenied
-  end
-
-  def require_admin!
-    authenticate_user!
-    if current_user.has_role?(:admin)
-      require_two_factor!
-      UserAction.admin_action.create(data: params)
-      return true
-    else
-      raise Acl9::AccessDenied
-    end
-  end
-
-  def require_two_factor!
-    warden.authenticate!(scope: :two_factor)
-  end
-
 end

--- a/app/helpers/roles_helper.rb
+++ b/app/helpers/roles_helper.rb
@@ -1,0 +1,30 @@
+module RolesHelper
+
+  def require_owner_or_admin!
+    require_owner!
+  rescue Acl9::AccessDenied => e
+    require_admin!
+  end
+
+  def require_owner!
+    authenticate_user!
+    current_user.has_role_for?(resource) or raise Acl9::AccessDenied
+  end
+
+  def require_admin!
+    authenticate_user!
+    if current_user.has_role?(:admin)
+      require_two_factor!
+      UserAction.admin_action.create(data: params)
+      return true
+    else
+      raise Acl9::AccessDenied
+    end
+  end
+
+  def require_two_factor!
+    warden.authenticate!(scope: :two_factor)
+  end
+
+  # helper_method(:require_owner_or_admin!, :require_owner!, :require_admin!, :require_two_factor!)
+end

--- a/lib/doorkeeper_patches/controllers/doorkeeper/application_controller.rb
+++ b/lib/doorkeeper_patches/controllers/doorkeeper/application_controller.rb
@@ -1,5 +1,4 @@
-module Doorkeeper
-  class ApplicationController < ::ApplicationController
-    include Helpers::Controller
-  end
+class Doorkeeper::ApplicationController < ActionController::Base
+  include Doorkeeper::Helpers::Controller
+  include RolesHelper
 end

--- a/spec/feature_helper.rb
+++ b/spec/feature_helper.rb
@@ -35,6 +35,8 @@ class SecretController < ApplicationController
   before_filter :authenticate_user!
   before_filter :require_admin!, only: [:admin]
 
+  include RolesHelper
+  
   def secret
     render text: 'you got me'
   end


### PR DESCRIPTION
Becuase `Doorkeeper::ApplicationController` does not inherit from our `ApplicationController`, it does not get helper methods defined in `ApplicationController` ... but it can get mixins.
