### PR TITLE
fix doorkeeper csrf issue

### DIFF
--- a/lib/doorkeeper_patches.rb
+++ b/lib/doorkeeper_patches.rb
@@ -1,3 +1,5 @@
+require 'doorkeeper_patches/controllers/application_controller'
+
 require 'doorkeeper_patches/models/access_grant'
 require 'doorkeeper_patches/models/access_token'
 require 'doorkeeper_patches/models/application'

--- a/lib/doorkeeper_patches/controllers/application_controller.rb
+++ b/lib/doorkeeper_patches/controllers/application_controller.rb
@@ -1,0 +1,3 @@
+class Doorkeeper::ApplicationController < ApplicationController
+  include Doorkeeper::Helpers::Controller
+end


### PR DESCRIPTION
I don't really like their fix (implement the CSRF protection in the Doorkeeper::ApplicationController, rather than inherit from our ApplicationController). Since we don't need the dashboard helper (b/c we built our own admin dashboard), it's simple enough to just overwrite the Doorkeeper::ApplicationController to inherit from our ApplicationController.
