### PR TITLE
Setup logstasher to create a JSON log

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -82,4 +82,5 @@ group :staging, :production do
 end
 
 group :production do
+  gem 'logstasher'
 end

--- a/config/environments/production.rb.example
+++ b/config/environments/production.rb.example
@@ -100,4 +100,10 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+
+  # Logstasher
+  config.logstasher.enabled = true
+  config.logstasher.suppress_app_log = false
+  config.logstasher.source = 'myusa'
+  config.logstasher.backtrace = true
 end


### PR DESCRIPTION
Logstasher is a gem that create a separate log file in JSON(-ish) format.

We are going to capture that log with logstash and this format makes it possible.

The setting `config.logstasher.suppress_app_log` is off for now to keep the current log.
