### PR TITLE
Hide apps when none exist

### DIFF
--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -37,6 +37,11 @@ class ApplicationsController < ApplicationController
     end
   end
 
+  def destroy
+    flash[:notice] = I18n.t(:notice, scope: [:doorkeeper, :flash, :applications, :destroy]) if @application.destroy
+    redirect_to authorizations_path
+  end
+
   # TODO: roll this into update
   def new_api_key
     @application = Doorkeeper::Application.find(params[:id])

--- a/app/views/doorkeeper/authorized_applications/index.html.erb
+++ b/app/views/doorkeeper/authorized_applications/index.html.erb
@@ -5,13 +5,13 @@
   <div class="col-md-9">
     <h1>
       My Applications
+      <div class="pull-right">
+        <%= link_to 'New Application', new_oauth_application_path, class: 'btn btn-success' %>
+      </div>
     </h1>
     <% if !@applications.empty? %>
       <h2>
         Developer applications
-        <div class="pull-right">
-          <%= link_to 'New Application', new_oauth_application_path, class: 'btn btn-success' %>
-        </div>
       </h2>
 
       <table class="table table-striped">

--- a/app/views/doorkeeper/authorized_applications/index.html.erb
+++ b/app/views/doorkeeper/authorized_applications/index.html.erb
@@ -6,53 +6,55 @@
     <h1>
       My Applications
     </h1>
-    <h2>
-      Developer applications
-      <div class="pull-right">
-        <%= link_to 'New Application', new_oauth_application_path, class: 'btn btn-success' %>
-      </div>
-    </h2>
+    <% if !@applications.empty? %>
+      <h2>
+        Developer applications
+        <div class="pull-right">
+          <%= link_to 'New Application', new_oauth_application_path, class: 'btn btn-success' %>
+        </div>
+      </h2>
 
-    <table class="table table-striped">
-      <thead>
-      <tr>
-        <th>Name</th>
-        <th>Status</th>
-        <th>Actions</th>
-      </tr>
-      </thead>
-      <tbody>
-      <% if @applications.blank? %>
+      <table class="table table-striped">
+        <thead>
         <tr>
-          <td colspan="3">
-            You do not have any applications.
-          </td>
+          <th>Name</th>
+          <th>Status</th>
+          <th>Actions</th>
         </tr>
-      <% end %>
-      <% @applications.each do |application| %>
-        <tr id="application_<%= application.id %>">
-          <td><%= link_to application.name, edit_oauth_application_path(application) %></td>
-          <td><%= app_status(application) %></td>
-          <td>
-            <%= form_tag new_api_key_path, method: :post do %>
-              <%= hidden_field_tag(:id, application.id) %>
-              <%= submit_tag 'New API Key',
-                onclick: "return confirm('Are you sure you want to generate a new client secret key?')",
-                class: 'btn btn-link' %>
-            <% end %>
-            <%= link_to 'Edit Application', edit_oauth_application_path(application), class: 'btn btn-link' %>
-            <% if !application.public && application.requested_public_at.nil? %>
-              <%= form_tag make_public_path, method: :post do %>
+        </thead>
+        <tbody>
+        <% if @applications.blank? %>
+          <tr>
+            <td colspan="3">
+              You do not have any applications.
+            </td>
+          </tr>
+        <% end %>
+        <% @applications.each do |application| %>
+          <tr id="application_<%= application.id %>">
+            <td><%= link_to application.name, edit_oauth_application_path(application) %></td>
+            <td><%= app_status(application) %></td>
+            <td>
+              <%= form_tag new_api_key_path, method: :post do %>
                 <%= hidden_field_tag(:id, application.id) %>
-                <%= submit_tag 'Request Public Access', class: 'btn btn-link' %>
+                <%= submit_tag 'New API Key',
+                  onclick: "return confirm('Are you sure you want to generate a new client secret key?')",
+                  class: 'btn btn-link' %>
               <% end %>
-            <% end %>
-            <%= render 'delete_form', application: application %>
-          </td>
-        </tr>
-      <% end %>
-      </tbody>
-    </table>
+              <%= link_to 'Edit Application', edit_oauth_application_path(application), class: 'btn btn-link' %>
+              <% if !application.public && application.requested_public_at.nil? %>
+                <%= form_tag make_public_path, method: :post do %>
+                  <%= hidden_field_tag(:id, application.id) %>
+                  <%= submit_tag 'Request Public Access', class: 'btn btn-link' %>
+                <% end %>
+              <% end %>
+              <%= render 'delete_form', application: application %>
+            </td>
+          </tr>
+        <% end %>
+        </tbody>
+      </table>
+    <% end %>
 
     <h2>Authorized Applications</h2>
 

--- a/lib/doorkeeper_patches/models/application.rb
+++ b/lib/doorkeeper_patches/models/application.rb
@@ -4,6 +4,7 @@ class Doorkeeper::Application
   include Doorkeeper::Models::Scopes
 
   acts_as_authorization_object
+  has_many :authorizations, dependent: :destroy
 
   validates_format_of :logo_url, with: URI.regexp(['https']),
                                  allow_blank: true,

--- a/spec/factories/application.rb
+++ b/spec/factories/application.rb
@@ -21,5 +21,9 @@ FactoryGirl.define do
       federal_agency true
       terms_of_service_accepted true
     end
+
+    trait(:private) do
+      public false
+    end
   end
 end

--- a/spec/models/doorkeeper/application_spec.rb
+++ b/spec/models/doorkeeper/application_spec.rb
@@ -21,6 +21,18 @@ describe Doorkeeper::Application do
     end
   end
 
+  describe 'destroy' do
+    before :each do
+      FactoryGirl.create(:authorization, application: application)
+    end
+
+    it 'deletes authorization objects' do
+      expect do
+        application.destroy
+      end.to change { Authorization.count }.by(-1)
+    end
+  end
+
   describe 'validations' do
     context 'application is not owned by a federal agency and does not have TOS accepted' do
       let(:application) { FactoryGirl.build(:application, federal_agency: false, terms_of_service_accepted: false) }


### PR DESCRIPTION
When the user does not have any OAuth Applications, we should hide it. This puts the Authorizations at the top of the page.

https://github.com/18F/myusa/issues/475