### PR TITLE
Use Bootstrap collapse to hide privacy act notice

### DIFF
--- a/app/views/application/_privacy_act.html.erb
+++ b/app/views/application/_privacy_act.html.erb
@@ -1,16 +1,25 @@
-PRIVACY ACT STATEMENT.
-<p>
-Authority: This collection is authorized by the E-Government Act of 2002 (P.L. 107-347).
-</p>
-<p>
-Purpose: We are collecting information that will allow users to establish a single account through which they can more easily interact with different parts of the Federal Government. 
-</p>
-<p>
-Routine Uses: We will share your information when you provide your consent.  In addition, there may be other circumstances where we may share your information.  Your information may be used when required in legal or administrative proceedings, given to agencies responsible for enforcing a statute or regulation, provided to Congress for constituent services or to the Office of Personnel Management, the Office of Management and Budget, or the Government Accountability Office for program evaluation purposes, shared with a consultant or contractor in the performance of a federal duty, given to the National Archives and Records Administration for records management purposes, shared with an agency when related to employee hiring or credentialing or issuance of a license or other benefit, or shared with an entity to redress a breach of the information system.
-</p>
-<p>
-Effects of Not Providing the Information: Providing information is voluntary, but failure to provide information will limit an individual’s ability to use MyUSA. 
-</p>
-<p>
-For additional information, please see the <%= link_to 'MyUSA Privacy Act System of Records Notice', 'http://www.gpo.gov/fdsys/pkg/FR-2013-07-05/pdf/2013-16124.pdf' %>.
-</p>
+For more details about MyUSA's use of this information, <a href="#privacyActStatement" data-toggle="collapse" aria-expanded="false" aria-controls="privacyActStatement">
+read our Privacy Act Statement <i class="fa fa-caret-right"></i>
+</a>
+<div class="collapse" id="privacyActStatement">
+  <div class="well">
+    <p>
+    <strong>PRIVACY ACT STATEMENT.</strong>
+    </p>
+    <p>
+    Authority: This collection is authorized by the E-Government Act of 2002 (P.L. 107-347).
+    </p>
+    <p>
+    Purpose: We are collecting information that will allow users to establish a single account through which they can more easily interact with different parts of the Federal Government. 
+    </p>
+    <p>
+    Routine Uses: We will share your information when you provide your consent.  In addition, there may be other circumstances where we may share your information.  Your information may be used when required in legal or administrative proceedings, given to agencies responsible for enforcing a statute or regulation, provided to Congress for constituent services or to the Office of Personnel Management, the Office of Management and Budget, or the Government Accountability Office for program evaluation purposes, shared with a consultant or contractor in the performance of a federal duty, given to the National Archives and Records Administration for records management purposes, shared with an agency when related to employee hiring or credentialing or issuance of a license or other benefit, or shared with an entity to redress a breach of the information system.
+    </p>
+    <p>
+    Effects of Not Providing the Information: Providing information is voluntary, but failure to provide information will limit an individual’s ability to use MyUSA. 
+    </p>
+    <p>
+    For additional information, please see the <%= link_to 'MyUSA Privacy Act System of Records Notice', 'http://www.gpo.gov/fdsys/pkg/FR-2013-07-05/pdf/2013-16124.pdf' %>.
+    </p>
+  </div>
+</div>


### PR DESCRIPTION
Since the Privacy Act notice is long and not often read, hide it in the normal flow.  Clicking on the link will then expand the privacy act notice.

Related to #459.