### PR TITLE
Allow client applications to request no scopes

### DIFF
--- a/lib/doorkeeper_patches/models/application.rb
+++ b/lib/doorkeeper_patches/models/application.rb
@@ -43,8 +43,7 @@ class Doorkeeper::Application
   scope :search, ->(search) { search.present? && where("name like (?)", "%#{search}%") }
 
   validate do |a|
-    return if a.scopes.nil?
-    unless Doorkeeper::OAuth::Helpers::ScopeChecker.valid?(a.scopes_string.to_s, Doorkeeper.configuration.scopes)
+    if a.scopes_string.present? && !Doorkeeper::OAuth::Helpers::ScopeChecker.valid?(a.scopes_string.to_s, Doorkeeper.configuration.scopes)
       errors.add(:scopes, 'Invalid scope')
     end
   end

--- a/spec/controllers/oauth/authorizations_controller_spec.rb
+++ b/spec/controllers/oauth/authorizations_controller_spec.rb
@@ -70,6 +70,11 @@ describe Oauth::AuthorizationsController do
           expect(user.profile.reload.last_name).to eq('McTesterson')
         end
       end
+
+      context 'with no scopes' do
+        let(:requested_scope) { nil }
+        it_behaves_like 'oauth'
+      end
     end
 
   end

--- a/spec/features/doorkeeper/oauth_spec.rb
+++ b/spec/features/doorkeeper/oauth_spec.rb
@@ -189,7 +189,7 @@ describe 'OAuth' do
         end
 
         context 'when no scopes are requested' do
-          let(:requested_scopes) { '' }
+          let(:requested_scopes) { nil }
           it_behaves_like 'uses existing authorization'
         end
       end

--- a/spec/models/doorkeeper/application_spec.rb
+++ b/spec/models/doorkeeper/application_spec.rb
@@ -80,6 +80,13 @@ describe Doorkeeper::Application do
         expect(application).not_to be_valid
       end
     end
+
+    context 'with no scopes' do
+      it 'is valid' do
+        application.scopes = nil
+        expect(application).to be_valid
+      end
+    end
   end
 
   describe '#logo_url' do


### PR DESCRIPTION
note: client applications are already allowed to request no scope. everything will just work. this PR is to let users create client applications that CANNOT request scopes.