### PR TITLE
Fix "Data too long for column 'description'" error.

### DIFF
--- a/app/views/applications/_form.html.erb
+++ b/app/views/applications/_form.html.erb
@@ -14,7 +14,7 @@
   <%= content_tag :div, class: "form-group#{' has-error' if application.errors[:description].present?}" do %>
     <div class="form-group">
       <%= f.label :description, class: 'control-label', for: 'application_description' %>
-      <%= f.text_area(:description, size:'50x5', class: 'form-control')%>
+      <%= f.text_area(:description, size:'50x5', class: 'form-control', maxlength: 255)%>
       <%= errors_for application, :description %>
     </div>
   <% end %>

--- a/lib/doorkeeper_patches/models/application.rb
+++ b/lib/doorkeeper_patches/models/application.rb
@@ -27,6 +27,8 @@ class Doorkeeper::Application
   validates_presence_of :privacy_policy_link,
     if: :tos_link?, accept: true, allow_nil: false,
     message: :privacy_policy_link_required
+    
+  validates :description, length: { maximum: 255 }
 
   before_save :clear_requested_public_at, if: ->(a) { a.public_changed? && a.public }
 

--- a/spec/models/doorkeeper/application_spec.rb
+++ b/spec/models/doorkeeper/application_spec.rb
@@ -2,6 +2,16 @@ require 'rails_helper'
 
 describe Doorkeeper::Application do
   let(:application) { FactoryGirl.create(:application) }
+  let(:short_description) do
+    %q{
+    Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. 
+    }
+  end
+  let(:long_description) do
+    %q{
+    Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam aliquam quaerat voluptatem. Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis suscipit laboriosam, nisi ut aliquid ex ea commodi consequatur? Quis autem vel eum iure reprehenderit qui in ea voluptate velit esse quam nihil molestiae consequatur, vel illum qui dolorem eum fugiat quo voluptas nulla pariatur?
+    }
+  end
 
   describe 'auditing' do
     context 'creation' do
@@ -58,6 +68,20 @@ describe Doorkeeper::Application do
 
       context 'TOS is accepted' do
         let(:application) { FactoryGirl.build(:application, :federal_agency, terms_of_service_accepted: true) }
+        it 'does not fail validation' do
+          expect(application.save).to be_truthy
+        end
+      end
+      
+      context 'description is longer than 255 characters' do
+        let(:application) { FactoryGirl.build(:application, :federal_agency, description: long_description) }
+        it 'fails validation' do
+          expect(application.save).to be_falsy
+        end
+      end
+      
+      context 'description is 255 characters or under' do
+        let(:application) { FactoryGirl.build(:application, :federal_agency, description: short_description) }
         it 'does not fail validation' do
           expect(application.save).to be_truthy
         end


### PR DESCRIPTION
Fixes #567 reported by @mbland.

Error fixed:

```
Error message
ActiveRecord::StatementInvalid: Data too long for column 'description' at row 1
```
New Relic link: https://rpm.newrelic.com/accounts/766782/applications/3823191/traced_errors/3166076747

 