### PR TITLE
Updated poltergeist gem to use PhantomJS 2.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,7 +84,7 @@ GEM
       net-ssh-gateway (>= 1.1.0)
     capistrano-unicorn (0.2.0)
       capistrano (< 3.0)
-    capybara (2.4.1)
+    capybara (2.4.4)
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
       rack (>= 1.0.0)
@@ -252,7 +252,7 @@ GEM
       treetop (~> 1.4.8)
     method_source (0.8.2)
     mime-types (1.25.1)
-    mini_portile (0.6.0)
+    mini_portile (0.6.2)
     minitar (0.5.4)
     minitest (5.4.0)
     mixlib-authentication (1.3.0)
@@ -261,7 +261,7 @@ GEM
     mixlib-config (2.1.0)
     mixlib-log (1.6.0)
     mixlib-shellout (1.4.0)
-    multi_json (1.10.1)
+    multi_json (1.11.0)
     multi_xml (0.5.5)
     multipart-post (2.0.0)
     mysql2 (0.3.16)
@@ -281,8 +281,8 @@ GEM
       net-ssh-gateway (>= 1.2.0)
     newrelic_rpm (3.9.9.275)
     nio4r (1.0.0)
-    nokogiri (1.6.3.1)
-      mini_portile (= 0.6.0)
+    nokogiri (1.6.6.2)
+      mini_portile (~> 0.6.0)
     nori (1.1.5)
     oauth2 (1.0.0)
       faraday (>= 0.8, < 0.10)
@@ -324,7 +324,7 @@ GEM
     permanent_records (2.3.0)
       activerecord
     plist (3.1.0)
-    poltergeist (1.5.1)
+    poltergeist (1.6.0)
       capybara (~> 2.1)
       cliver (~> 0.3.1)
       multi_json (~> 1.0)
@@ -339,11 +339,11 @@ GEM
       pry (>= 0.9.10)
     quiet_assets (1.0.3)
       railties (>= 3.1, < 5.0)
-    rack (1.5.2)
+    rack (1.5.3)
     rack-openid (1.3.1)
       rack (>= 1.1.0)
       ruby-openid (>= 2.1.8)
-    rack-test (0.6.2)
+    rack-test (0.6.3)
       rack (>= 1.0)
     rails (4.1.5)
       actionmailer (= 4.1.5)
@@ -518,7 +518,9 @@ GEM
       rack (>= 1.0)
     wasabi (1.0.0)
       nokogiri (>= 1.4.0)
-    websocket-driver (0.3.4)
+    websocket-driver (0.5.4)
+      websocket-extensions (>= 0.1.0)
+    websocket-extensions (0.1.2)
     will_paginate (3.0.7)
     winrm (1.1.3)
       gssapi (~> 1.0.0)
@@ -598,3 +600,6 @@ DEPENDENCIES
   unicorn
   validates_email_format_of
   will_paginate
+
+BUNDLED WITH
+   1.10.2


### PR DESCRIPTION
When you run a `brew install phantomjs` on a new laptop, it installs the most recent version of PhantomJS (2.0). The poltergeist gem that was in the `Gemfile.lock` was pinned to version 1.8 of PhantomJS, which was released in 2012. I have done a `bundle update poltergeist` which updated a few other dependencies as well. I have not done a general `bundle update` on all the gems (is that something we should consider?) It runs fine locally after this change.