### PR TITLE
Ensure email links have https protocol

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -26,7 +26,7 @@ Rails.application.configure do
   # Disable request forgery protection in test environment.
   config.action_controller.allow_forgery_protection = false
 
-  config.action_mailer.default_url_options = { :host => 'www.example.com' }
+  config.action_mailer.default_url_options = { host: 'www.example.com', protocol: 'https' }
 
   # Tell Action Mailer not to deliver emails to the real world.
   # The :test delivery method accumulates sent emails in the

--- a/spec/features/devise/sessions/sign_in_spec.rb
+++ b/spec/features/devise/sessions/sign_in_spec.rb
@@ -113,6 +113,12 @@ describe 'Sign In' do
         expect(current_email).to have_link(email_link_text)
       end
 
+      it 'sends an HTTPS link' do
+        open_email(email)
+        link = current_email.find_link(email_link_text)
+        expect(link[:href]).to match(/^https/)
+      end
+
       describe 'resending token via email' do
         before :each do
           token_instructions_page.resend_link.click


### PR DESCRIPTION
Fix for #650, with @harrisj. 

Note that this depends on `config.action_mailer.default_url_options` being set correctly in `($RAILS_ENV).rb` - am making that change to the Cloud Foundry branch too.