### PR TITLE
Add url field to Task model, external_id to TaskItem

### DIFF
--- a/api_docs/task.md
+++ b/api_docs/task.md
@@ -38,7 +38,8 @@ Create a new task for the user for this application.
 + Parameters
 
 + name (required, string, `Test task`) ...The name for the task that is being created.
-+ task_items_atributes(optional, hash, `{:id=>1, :name=>'Task attribute' }`) ...A list of task items to be associated with the task.
++ url (optional, string, 'http://18f.gsa.gov') ...an optional URL for the Task. Note you can define URLs for task items too.
++ task_items_atributes(optional, hash, `{:id=>1, :name=>'Task attribute', :url => 'optional url', :external_id => 'optional ID string' }`) ...A list of task items to be associated with the task. The External ID field is provided for your convenience to more easily map task items to records on your own system.
 
 + Request Create a new task (application/json)
 
@@ -123,11 +124,15 @@ Update a task
       }
     }
 
+Note that if the task or one of its attributes has defined values for fields that are not explicitly included in the PUT request,
+those values will be preserved and will not be overwritten.
+
 + Response 200 (application/json; charset=utf-8)
 
     {
       "id": 1,
       "name": "New Task",
+      "url": "This URL was not updated",
       "completed_at": "2014-07-07T17:59:21.000Z",
       "user_id": 1,
       "created_at": "2014-07-08T17:59:21.000Z",

--- a/app/controllers/api/v1/tasks_controller.rb
+++ b/app/controllers/api/v1/tasks_controller.rb
@@ -47,11 +47,11 @@ class Api::V1::TasksController < Api::ApiController
   end
 
   def task_params
-    params.require(:task).permit(:name, :completed_at, task_items_attributes:[:name])
+    params.require(:task).permit(:name, :url, :completed_at, task_items_attributes:[:name])
   end
 
   def update_task_params
-    params.require(:task).permit(:name, :completed_at, task_items_attributes:[:id, :name])
+    params.require(:task).permit(:name, :url, :completed_at, task_items_attributes:[:id, :name])
   end
 
 end

--- a/app/controllers/api/v1/tasks_controller.rb
+++ b/app/controllers/api/v1/tasks_controller.rb
@@ -1,5 +1,6 @@
 class Api::V1::TasksController < Api::ApiController
   doorkeeper_for :all, scopes: ['tasks']
+  wrap_parameters :task, include: [:name, :url, :completed_at, :task_items_attributes]
 
   def index
     @tasks = current_resource_owner.tasks.where(:app_id => doorkeeper_token.application.id).joins(:task_items)

--- a/app/controllers/api/v1/tasks_controller.rb
+++ b/app/controllers/api/v1/tasks_controller.rb
@@ -47,11 +47,11 @@ class Api::V1::TasksController < Api::ApiController
   end
 
   def task_params
-    params.require(:task).permit(:name, :url, :completed_at, task_items_attributes:[:name])
+    params.require(:task).permit(:name, :url, :completed_at, task_items_attributes:[:name, :external_id])
   end
 
   def update_task_params
-    params.require(:task).permit(:name, :url, :completed_at, task_items_attributes:[:id, :name])
+    params.require(:task).permit(:name, :url, :completed_at, task_items_attributes:[:id, :name, :external_id])
   end
 
 end

--- a/db/migrate/20150617151530_add_url_field_to_tasks_model.rb
+++ b/db/migrate/20150617151530_add_url_field_to_tasks_model.rb
@@ -1,0 +1,5 @@
+class AddUrlFieldToTasksModel < ActiveRecord::Migration
+  def change
+   	add_column :tasks, :url, :string
+  end
+end

--- a/db/migrate/20150617160707_add_external_id_to_task_items.rb
+++ b/db/migrate/20150617160707_add_external_id_to_task_items.rb
@@ -1,0 +1,5 @@
+class AddExternalIdToTaskItems < ActiveRecord::Migration
+  def change
+    add_column :task_items, :external_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150303184510) do
+ActiveRecord::Schema.define(version: 20150617151530) do
 
   create_table "authentication_tokens", force: true do |t|
     t.integer  "user_id"
@@ -216,6 +216,7 @@ ActiveRecord::Schema.define(version: 20150303184510) do
     t.datetime "created_at",   null: false
     t.datetime "updated_at",   null: false
     t.integer  "app_id"
+    t.string   "url"
   end
 
   add_index "tasks", ["app_id"], name: "index_tasks_on_app_id", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150617151530) do
+ActiveRecord::Schema.define(version: 20150617160707) do
 
   create_table "authentication_tokens", force: true do |t|
     t.integer  "user_id"
@@ -205,6 +205,7 @@ ActiveRecord::Schema.define(version: 20150617151530) do
     t.integer  "task_id"
     t.datetime "created_at",   null: false
     t.datetime "updated_at",   null: false
+    t.string   "external_id"
   end
 
   add_index "task_items", ["task_id"], name: "index_task_items_on_task_id", using: :btree

--- a/spec/requests/v1/api_spec.rb
+++ b/spec/requests/v1/api_spec.rb
@@ -208,7 +208,7 @@ describe Api::V1 do
     end
 
     describe 'POST /api/v1/tasks' do
-      let(:params) { {task: { name: 'New Task', url: "http://wwww.gsa.gov/", task_items_attributes: [name: "Item 1", external_id: "abc"]}} }
+      let(:params) { {task: { name: 'New Task', url: "http://wwww.gsa.gov/", task_items_attributes: [{name: "Item 1", external_id: "abc"}]}} }
       subject { post '/api/v1/tasks', params, header }
 
       context 'when the caller has a valid token' do

--- a/spec/requests/v1/api_spec.rb
+++ b/spec/requests/v1/api_spec.rb
@@ -253,19 +253,22 @@ describe Api::V1 do
             completed_at: Time.now-1.day,
             user_id: user.id,
             app_id: client_app.id,
-            task_items_attributes: [{ name: 'Task item one' }]
+            task_items_attributes: [{ name: 'Task item one', external_id: 'abcdef' }]
           })
         end
 
         context 'when valid parameters are used' do
-          let(:params) { { task: { name: 'New Task', url: "http://18f.gsa.gov", task_items_attributes: [{ id: task.task_items.first.id, name: 'Task item one' }] }} }
+          let(:params) { { task: { name: 'New Task', url: "http://18f.gsa.gov", task_items_attributes: [{ id: task.task_items.first.id, name: 'Task item one A' }] }} }
 
           it 'should update the task and task items' do
             expect(subject.status).to eq 200
             parsed_json = JSON.parse(subject.body)
             expect(parsed_json['name']).to eq 'New Task'
             expect(parsed_json['url']).to eq 'http://18f.gsa.gov'
-            expect(parsed_json['task_items'].first['name']).to eq 'Task item one'
+            expect(parsed_json['task_items'].first['name']).to eq 'Task item one A'
+
+            # this shouldn't be changed by the put
+            expect(parsed_json['task_items'].first['external_id']).to eq 'abcdef'
           end
 
           it 'creates an user action record' do
@@ -283,7 +286,7 @@ describe Api::V1 do
             }).tap {|t| t.complete! }
           end
 
-          let(:params) { {task: { name: 'New Incomplete Task', url: 'http://whitehouse.gov', completed_at: nil, task_items_attributes: [{ id: task.task_items.first.id, name: 'Task item one' }] }} }
+          let(:params) { {task: { name: 'New Incomplete Task', url: 'http://whitehouse.gov', completed_at: nil, task_items_attributes: [{ id: task.task_items.first.id, name: 'Task item one', external_id: 'abc' }] }} }
 
           it 'should no longer be marked as complete when specified' do
             expect(subject.status).to eq 200
@@ -291,6 +294,7 @@ describe Api::V1 do
             expect(parsed_json['name']).to eq 'New Incomplete Task'
             expect(parsed_json['url']).to eq 'http://whitehouse.gov'
             expect(parsed_json['task_items'].first['name']).to eq 'Task item one'
+            expect(parsed_json['task_items'].first['external_id']).to eq 'abc'
           end
 
           it 'creates an user action record' do


### PR DESCRIPTION
Added a `url` field to the Task model and `external_id` to the TaskItem model. This PR does require DB migrations to be run. (Fixes #678)