### PR TITLE
Remove use of the MC:SUBJECT Mailchimp template tag in emails

### DIFF
--- a/app/views/devise_mailer/authentication_instructions.html.erb
+++ b/app/views/devise_mailer/authentication_instructions.html.erb
@@ -2,8 +2,8 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
 	<head>
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-        <title>*|MC:SUBJECT|*</title>
         <%= stylesheet_link_tag "mailers" %>
+				<title><%= t "email.authentication.subject" %></title>
     </head>
     <body leftmargin="0" marginwidth="0" topmargin="0" marginheight="0" offset="0">
     	<center>

--- a/app/views/devise_mailer/authentication_instructions.html.erb
+++ b/app/views/devise_mailer/authentication_instructions.html.erb
@@ -3,7 +3,7 @@
 	<head>
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
         <%= stylesheet_link_tag "mailers" %>
-				<title><%= t "email.authentication.subject" %></title>
+        <title><%= t "email.authentication.subject" %></title>
     </head>
     <body leftmargin="0" marginwidth="0" topmargin="0" marginheight="0" offset="0">
     	<center>

--- a/app/views/layouts/mailers/notification_template.html.erb
+++ b/app/views/layouts/mailers/notification_template.html.erb
@@ -2,8 +2,8 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-    <title>*|MC:SUBJECT|*</title>
     <%= stylesheet_link_tag "mailers" %>
+    <title><%= @metadata[:title] %></title>
   </head>
   <body leftmargin="0" marginwidth="0" topmargin="0" marginheight="0" offset="0">
     <center>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -231,6 +231,8 @@ en:
       subject: '%{name} requested public access'
     notification:
       subject: 'Message from %{name} about %{subject}'
+    authentication:
+      subject: Authenticate With MyUSA
 
   mobile_confirmation:
     skip_this_step: 'You can add your mobile number on your <a href="%{profile_link}">MyUSA profile</a> at another time.'


### PR DESCRIPTION
Referenced here in https://github.com/18F/myusa/issues/618#issuecomment-114138138

Mailchimp/Mandrill allows you to specify a campaign-wide subject for your emails that can be referenced in your templates. Decided to have this be set by the application instead before the email is pushed up to Mandrill for delivery. In addition, set it so `email.authentication.subject` is set in the English localization file to match the configuration for notification emails.