### PR TITLE
Email should default to be shared on Oauth Permissions page

### DIFF
--- a/app/helpers/scopes_helper.rb
+++ b/app/helpers/scopes_helper.rb
@@ -99,6 +99,13 @@ module ScopesHelper
     value.present?
   end
 
+  def scope_value_required?(scope)
+    # FIXME: inelegant hack for now to make the email required for now.
+    # Look into a mechanism for applications to specify other required
+    # scopes or possibly default sharing scopes yet
+    scope == 'profile.email'
+  end
+
   def scope_field_tag(scope, opts = {})
     return unless profile_scope?(scope)
     read_only = opts.delete :read_only

--- a/app/views/doorkeeper/authorizations/_scope_list.html.erb
+++ b/app/views/doorkeeper/authorizations/_scope_list.html.erb
@@ -22,6 +22,7 @@
                name="scope[]"
                tabindex="0"
                aria-describedby="<%= scope_id(scope) %> share_col section_<%= "#{index+1}" %>"
+               <% if scope_value_required?(scope) %>checked<%- end %>
                value="<%= scope %>">
           <div class="checkbox" role="checkbox" tabindex="-1">
             <span>YES</span>


### PR DESCRIPTION
This hotfix [fixes issue #15 on myusa-ux](https://github.com/18F/myusa-ux/issues/15) by defaulting email sharing to on. The current staging MyUSA is causing issues with The Hub, since all permissions including email address are defaulting to off. This code makes email sharing default to on.

![myusa](https://cloud.githubusercontent.com/assets/2044/8561427/6cca9c5a-24f3-11e5-84f6-e7c81c9294e6.jpg)
