### PR TITLE
Upgraded doorkeeper and jquery-rails gems to fix vulnerabilities

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem 'rails', '4.1.9' # update to 4.1.12 when released, due to
                      # In our case, specs fail because of simple_role::has_role?
 gem 'sass-rails', '~> 4.0.3'
 gem 'uglifier', '>= 1.3.0'
-gem 'jquery-rails'
+gem 'jquery-rails', '~> 3.1.3'
 gem 'turbolinks'
 gem 'mysql2'
 ## app dependencies

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,7 +88,7 @@ GEM
       warden (~> 1.2.3)
     diff-lcs (1.2.5)
     docile (1.1.5)
-    doorkeeper (1.4.1)
+    doorkeeper (1.4.2)
       railties (>= 3.1)
     em-websocket (0.5.1)
       eventmachine (>= 0.12.9)
@@ -124,10 +124,10 @@ GEM
     hitimes (1.2.2)
     http_parser.rb (0.6.0)
     i18n (0.7.0)
-    jquery-rails (3.1.1)
+    jquery-rails (3.1.3)
       railties (>= 3.0, < 5.0)
       thor (>= 0.14, < 2.0)
-    json (1.8.2)
+    json (1.8.3)
     jwt (1.0.0)
     kgio (2.9.2)
     launchy (2.4.2)
@@ -148,7 +148,7 @@ GEM
     method_source (0.8.2)
     mime-types (1.25.1)
     mini_portile (0.6.2)
-    minitest (5.4.0)
+    minitest (5.7.0)
     multi_json (1.11.1)
     multi_xml (0.5.5)
     multipart-post (2.0.0)
@@ -363,7 +363,7 @@ DEPENDENCIES
   fakeweb
   font-awesome-sass
   guard-livereload
-  jquery-rails
+  jquery-rails (~> 3.1.3)
   letter_opener
   logstasher
   mysql2


### PR DESCRIPTION
Here is a fix for the critical vulnerabilities outlined by gemnasium in #705. We probably want to consider upgrading other gems that are old. Eventually we will also probably want to move to v2.0 and above of Doorkeeper. But this fixes the immediate problem.