### PR TITLE
Eliminate warnings + other noise during test runs

### DIFF
--- a/app/views/devise_mailer/authentication_instructions.html.erb
+++ b/app/views/devise_mailer/authentication_instructions.html.erb
@@ -36,7 +36,7 @@
                                     <table border="0" cellpadding="0" cellspacing="0" width="100%" id="templateHeader">
                                         <tr>
                                             <td valign="top" class="headerContent">
-                                            <%= image_tag attachments['logo.png'].url, alt: 'Sent by MyUSA', class: 'photo', height: '38', width: '134', class: 'left-20' %>
+                                            <%= image_tag attachments['logo.png'].url, alt: 'Sent by MyUSA', class: 'photo left-20', height: '38', width: '134' %>
                                             </td>
                                         </tr>
                                     </table>

--- a/app/views/layouts/mailers/notification_template.html.erb
+++ b/app/views/layouts/mailers/notification_template.html.erb
@@ -18,7 +18,7 @@
                   <table border="0" cellpadding="0" cellspacing="0" width="100%" id="templatePreheader">
                     <tr>
                       <td valign="top" class="preheaderContent" style="padding-top:10px; padding-right:20px; padding-bottom:10px; padding-left:20px;" mc:edit="preheader_content00">
-                      <%= link_to image_tag(attachments['logo.png'].url, alt: 'Sent from MyUSA', height: '25', width: '88', alt: 'Sent from MyUSA'), root_url %>
+                      <%= link_to image_tag(attachments['logo.png'].url, alt: 'Sent from MyUSA', height: '25', width: '88'), root_url %>
                       </td>
                       <!-- *|IFNOT:ARCHIVE_PAGE|* -->
                       <td valign="top" width="180" class="preheaderContent" style="padding-top:10px; padding-right:20px; padding-bottom:10px; padding-left:0;" mc:edit="preheader_content01"></td>

--- a/spec/requests/omniauth_spec.rb
+++ b/spec/requests/omniauth_spec.rb
@@ -3,15 +3,12 @@ require 'spec_helper'
 describe 'OmniAuth' do
   let(:email) { 'test@example.gov' }
   let(:omniauth_provider) { :google_oauth2 }
-  let(:omniauth_uid) { 12345 }
 
   let(:omniauth_hash) do
     OmniAuth::AuthHash.new(
       provider: omniauth_provider,
-      uid: omniauth_uid,
-      info: {
-        email: email
-      }
+      uid: 1234,
+      info: { email: email }
     )
   end
 
@@ -22,7 +19,11 @@ describe 'OmniAuth' do
 
   shared_examples 'success' do
     it 'creates successful_authentication user action' do
-      expect { get '/users/auth/google_oauth2/callback' }.to change(UserAction.successful_authentication.where(data: "{\"authentication_method\":\"google_oauth2\"}"), :count).by(1)
+      successful_auths = UserAction.successful_authentication.
+        where(data: "{\"authentication_method\":\"google_oauth2\"}")
+
+      expect { get '/users/auth/google_oauth2/callback' }.
+        to change(successful_auths, :count).by(1)
     end
   end
 
@@ -32,18 +33,20 @@ describe 'OmniAuth' do
     end
 
     it 'does not create user' do
-      expect { get '/users/auth/google_oauth2/callback' }.to_not change(User, :count)
+      expect { get '/users/auth/google_oauth2/callback' }.
+        to_not change(User, :count)
     end
 
-    include_examples "success"
+    include_examples 'success'
   end
 
   context 'without existing user' do
     it 'creates user' do
-      expect { get '/users/auth/google_oauth2/callback' }.to change(User, :count).by(1)
+      expect { get '/users/auth/google_oauth2/callback' }.
+        to change(User, :count).by(1)
     end
 
-    include_examples "success"
+    include_examples 'success'
   end
 
   context 'failure' do
@@ -51,8 +54,17 @@ describe 'OmniAuth' do
       OmniAuth.config.mock_auth[omniauth_provider] = :invalid_credentials
     end
 
+    def visit_callback
+      OmniAuthSpecHelper.silence_omniauth do
+        get '/users/auth/google_oauth2/callback'
+      end
+    end
+
     it 'creates failed_authentication user action' do
-      expect { get '/users/auth/google_oauth2/callback' }.to change(UserAction.failed_authentication.where(data: "{\"authentication_method\":\"google_oauth2\"}"), :count).by(1)
+      failed_auths = UserAction.failed_authentication.
+        where(data: "{\"authentication_method\":\"google_oauth2\"}")
+
+      expect { visit_callback }.to change(failed_auths, :count).by(1)
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,10 +1,12 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 ENV['RAILS_ENV'] ||= 'test'
 
-require "codeclimate-test-reporter"
-CodeClimate::TestReporter.start
+if ENV['CODECLIMATE_REPO_TOKEN']
+  require 'codeclimate-test-reporter'
+  CodeClimate::TestReporter.start
+end
 
-require File.expand_path("../../config/environment", __FILE__)
+require File.expand_path('../../config/environment', __FILE__)
 require 'rspec/rails'
 require 'rspec/its'
 require 'capybara/rspec'
@@ -13,7 +15,7 @@ SmsSpec.driver = :"twilio-ruby"
 
 # Requires supporting ruby files with custom matchers and macros, etc,
 # in spec/support/ and its subdirectories.
-Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }
+Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
 
 # Checks for pending migrations before tests are run.
 # If you are not using ActiveRecord, you can remove this line.
@@ -31,7 +33,6 @@ class ActiveRecord::Base
 end
 
 ActiveRecord::Base.shared_connection = ActiveRecord::Base.connection
-
 
 RSpec.configure do |config|
   config.include FactoryGirl::Syntax::Methods
@@ -70,7 +71,7 @@ RSpec.configure do |config|
   # order dependency and want to debug it, you can fix the order by providing
   # the seed, which is printed after each run.
   #     --seed 1234
-  config.order = "random"
+  config.order = 'random'
 
   config.before(:suite) do
     DatabaseCleaner.strategy = :transaction

--- a/spec/support/omniauth_spec_helper.rb
+++ b/spec/support/omniauth_spec_helper.rb
@@ -1,0 +1,10 @@
+module OmniAuthSpecHelper
+  # http://stackoverflow.com/questions/19483367
+  def self.silence_omniauth
+    previous_logger = OmniAuth.config.logger
+    OmniAuth.config.logger = Logger.new('/dev/null')
+    yield
+  ensure
+    OmniAuth.config.logger = previous_logger
+  end
+end


### PR DESCRIPTION
This PR addresses 4 unnecessary statements that appear when running
`rspec`:

- Removed the duplicate `alt: 'Sent from MyUSA'` from
`notification_template.html.erb`

- Removed the duplicate `class` from
`authentication_instructions.html.erb` and added it to the existing class

- Silenced the omniauth error in `omniauth_spec`

- Silenced the Code Climate warning

- Fixed Rubocop offenses