### PR TITLE
Add Hound and Rubocop configuration files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@
 *.sassc
 **.orig
 .powrc
-.rubocop.yml
 .sass-cache
 .zeus.sock
 .DS_store

--- a/.hound.yml
+++ b/.hound.yml
@@ -1,0 +1,2 @@
+ruby:
+  config_file: .rubocop.yml

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,109 @@
+AllCops:
+  Include:
+    - 'Gemfile'
+    - 'Rakefile'
+    - 'lib/tasks/*'
+    - "**/*.rake"
+    - "**/Capfile"
+    - "**/Guardfile"
+    - "**/Vagrantfile"
+    - "**/Berksfile"
+    - "**/Cheffile"
+  Exclude:
+    - 'db/schema.rb'
+
+Lint/ParenthesesAsGroupedExpression:
+  Description: Checks for method calls with a space before the opening parenthesis.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#parens-no-spaces
+  Enabled: true
+
+Metrics/ClassLength:
+  Description: Avoid classes longer than 100 lines of code.
+  Enabled: true
+  CountComments: false
+  Max: 100
+
+Metrics/LineLength:
+  Description: Limit lines to 80 characters.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#80-character-limits
+  Enabled: true
+  Max: 80
+  AllowURI: true
+  URISchemes:
+  - http
+  - https
+
+Metrics/MethodLength:
+  Description: Avoid methods longer than 10 lines of code.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#short-methods
+  Enabled: true
+  CountComments: false
+  Max: 10
+
+Metrics/ModuleLength:
+  Description: Avoid modules longer than 100 lines of code.
+  Enabled: true
+  CountComments: false
+  Max: 100
+
+Rails/HasAndBelongsToMany:
+  Description: Prefer has_many :through to has_and_belongs_to_many.
+  Enabled: true
+  Include:
+  - app/models/**/*.rb
+
+Rails/ScopeArgs:
+  Description: Checks the arguments of ActiveRecord scopes.
+  Enabled: true
+  Include:
+  - app/models/**/*.rb
+
+Rails/TimeZone:
+  # The value `always` means that `Time` should be used with `zone`.
+  # The value `acceptable` allows usage of `in_time_zone` instead of `zone`.
+  Enabled: true
+  EnforcedStyle: always
+  SupportedStyles:
+    - always
+    - acceptable
+
+Style/AndOr:
+  Description: Use &&/|| instead of and/or.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-and-or-or
+  Enabled: true
+  EnforcedStyle: conditionals
+  SupportedStyles:
+  - always
+  - conditionals
+
+Style/Documentation:
+  Description: Document classes and non-namespace modules.
+  Enabled: false
+
+Style/DotPosition:
+  Description: Checks the position of the dot in multi-line method calls.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#consistent-multi-line-chains
+  Enabled: true
+  EnforcedStyle: trailing
+  SupportedStyles:
+  - leading
+  - trailing
+
+Style/ExtraSpacing:
+  Description: Do not use unnecessary spacing.
+  Enabled: false
+
+Style/GuardClause:
+  Description: Check for conditionals that can be replaced with guard clauses
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-nested-conditionals
+  Enabled: true
+  MinBodyLength: 1
+
+Style/StringLiterals:
+  Description: Checks if uses of quotes match the configured preference.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#consistent-string-literals
+  Enabled: true
+  EnforcedStyle: single_quotes
+  SupportedStyles:
+  - single_quotes
+  - double_quotes


### PR DESCRIPTION
Hound is a CI tool that allows you to enforce a consistent style in
your code based on style guide rules that you define. For Ruby, Hound
uses the rules defined by the Ruby Style Guide as enforced by Rubocop.

You don't have to agree with every rule, but you do have to be
consistent. If there are certain rules that you don't agree with, you
can modify them and place them in `.rubocop.yml`, as I've done here.
These are rules that I've used in past and current projects, and that
most people agree with.

I think having a consistent style across 18F projects would portray
cohesiveness, and will encourage more outside contributions if there
is only one style to follow.

Further reading:
https://houndci.com
https://github.com/bbatsov/ruby-style-guide/
https://github.com/bbatsov/rubocop
https://robots.thoughtbot.com/introducing-hound
https://robots.thoughtbot.com/why-does-style-matter