### PR TITLE
Remove unnecessarily duplicated config

### DIFF
--- a/config/environments/development.example.rb
+++ b/config/environments/development.example.rb
@@ -13,9 +13,9 @@ Rails.application.configure do
   config.consider_all_requests_local       = true
   config.action_controller.perform_caching = false
 
-  config.action_mailer.delivery_method = :test #letter_opener
+  config.action_mailer.delivery_method = :test # letter_opener
   config.myusa_sender_email = 'MyUSA <myusa@gsa.gov>'
-  
+
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false
 
@@ -38,9 +38,6 @@ Rails.application.configure do
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 
-  # SMS sender number.
-  # This is the number from which our 2FA SMS messages will be sent.
-  config.sms_sender_number = '+12407433320'
   config.sms_delivery_method = :email # or :twilio
 
   config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -14,6 +14,9 @@ Rails.application.configure do
   config.active_record.dump_schema_after_migration = false
 
   config.secret_key_base = ENV["SECRET_KEY_BASE"]
+  config.devise_secret_key = ENV['DEVISE_SECRET_KEY']
+  config.force_ssl = true
+  config.sms_delivery_method = :twilio
   config.myusa_sender_email = ENV['SENDER_EMAIL']
   config.action_mailer.default_url_options = { host: ENV['APP_HOST'], protocol: 'https' }
   config.action_mailer.raise_delivery_errors = true
@@ -27,23 +30,8 @@ Rails.application.configure do
     enable_starttls_auto: true
   }
 
-  config.sms_sender_number = ENV['SMS_NUMBER']
-  config.sms_delivery_method = :twilio
-
-  # For some reason, trying to access these config parameters in the
-  # initializers throws a method_missing, despite the configs set
-  # above being totally OK. No idea why, need to investigate. -- Yoz
-  config.twilio_account_sid = ENV['TWILIO_ACCOUNT_SID']
-  config.twilio_auth_token = ENV['TWILIO_AUTH_TOKEN']
-  config.devise_secret_key = ENV['DEVISE_SECRET_KEY']
-  config.omniauth_google_app_id = ENV['OMNIAUTH_GOOGLE_APP_ID']
-  config.omniauth_google_secret = ENV['OMNIAUTH_GOOGLE_SECRET']
-
-  config.force_ssl = true
-
-  unless ENV['ELASTICACHE_ENDPOINT'].blank?
-    endpoint    = ENV['ELASTICACHE_ENDPOINT'] + ":11211"
-    elasticache = Dalli::ElastiCache.new(endpoint)
-    config.cache_store = :dalli_store, elasticache.servers, {:expires_in => 1.day, :compress => true}
-  end
+  # For other environment config, see these initializers:
+  # OMNIAUTH_*: devise.rb
+  # ELASTICACHE_ENDPOINT: cache.rb
+  # TWILIO_*: twilio.rb
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -41,9 +41,6 @@ Rails.application.configure do
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 
-  # SMS sender number.
-  # This is the number from which our 2FA SMS messages will be sent.
-  config.sms_sender_number = '+12407433320'
   # SmsSpec is used to mock the Twilio requests
   config.sms_delivery_method = :twilio
 

--- a/config/initializers/cache.rb
+++ b/config/initializers/cache.rb
@@ -1,5 +1,6 @@
 unless ENV['ELASTICACHE_ENDPOINT'].blank?
   endpoint    = ENV['ELASTICACHE_ENDPOINT'] + ':11211'
   elasticache = Dalli::ElastiCache.new(endpoint)
-  config.cache_store = :dalli_store, elasticache.servers, {:expires_in => 1.day, :compress => true}
+  Rails.configuration.cache_store = :dalli_store, elasticache.servers,
+                                    { expires_in: 1.day, compress: true }
 end

--- a/config/initializers/twilio.rb
+++ b/config/initializers/twilio.rb
@@ -3,6 +3,6 @@ require 'sms_wrapper'
 SmsWrapper.setup do |config|
   config.twilio_account_sid = ENV['TWILIO_ACCOUNT_SID']
   config.twilio_auth_token = ENV['TWILIO_AUTH_TOKEN']
-  config.twilio_phone_number = Rails.configuration.sms_sender_number
+  config.twilio_phone_number = ENV['SMS_NUMBER']
   config.delivery_method = Rails.configuration.sms_delivery_method rescue :email
 end


### PR DESCRIPTION
Removes redundant and broken config from the `environments/` files.