### PR TITLE
Add tabindex to email login fields

### DIFF
--- a/app/views/devise/sessions/_email_option.html.erb
+++ b/app/views/devise/sessions/_email_option.html.erb
@@ -4,16 +4,16 @@
       <div class="form-group">
         <%= label_tag 'inputEmail', t('devise.enter_your_email'), class: 'blue_header' %>
         <div class="input-group">
-          <%= f.email_field :email, class: "form-control", id: "inputEmail", autofocus: true, placeholder: 'Email Address' %>
+          <%= f.email_field :email, class: "form-control", id: "inputEmail", autofocus: true, placeholder: 'Email Address', tabindex: "1" %>
           <span class="input-group-btn">
             <%= hidden_field_tag :login_required, params[:login_required] %>
-            <%= submit_tag 'Connect', :class => 'btn btn-primary connect_button', :type => 'submit' %>
+            <%= submit_tag 'Connect', :class => 'btn btn-primary connect_button', :type => 'submit', :tabindex => '3' %>
           </span>
         </div>
       </div>
       <div class="checkbox">
         <label>
-          <%= f.check_box :remember_me %>
+          <%= f.check_box :remember_me, tabindex: "2" %>
           Remember me on this computer for 2 weeks
         </label>
       </div>


### PR DESCRIPTION
Sorry for the start-of-the-weekend-PR, but I ran into issue #725 and thought it could be a quick fix.

I've added the tab index values for the email input field, the “Remember me” checkbox and the submit button on the email login view.

The order of the tabbing is:
1. Email input field
2. Remember me checkbox
3. Submit button

All tests are passing for me. Also, this was more of a personal usability issue than a general accessibility issue so please feel free to not merge this if you've got something larger planned.