### PR TITLE
Updated Contact Us form

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,2 +1,5 @@
 ruby:
   config_file: .rubocop.yml
+
+scss:
+  enabled: false

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -41,10 +41,10 @@ $(function() {
      }
 
      $('#contact-alert').show();
-  }).on('ajax:error', function(e, data, status, xhr) {
-    console.log(data);
 
-    if data.message {
+  }).on("ajax:error", function(e, data, status, xhr) {
+
+    if (data.message) {
       $('#contact-alert p.message').text(data.message);
     }
 

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -31,5 +31,23 @@ $(function() {
       }
     });
   });
-});
 
+  $("#contact-form").on("ajax:success", function(e, data, status, xhr) {
+     // TODO: should disable the submit button?
+     $('#contact-alert p.message').text(data.message);
+
+     if (data.success) {
+      $('#contact-alert').removeClass('error').addClass('success')
+     }
+
+     $('#contact-alert').show();
+  }).on('ajax:error', function(e, data, status, xhr) {
+    console.log(data);
+
+    if data.message {
+      $('#contact-alert p.message').text(data.message);
+    }
+
+    $('#contact-alert').show();
+  });
+});

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -17,8 +17,9 @@
 //= require bootstrap-sprockets
 //= require myusa
 //= require bootstrap-tokenfield
+//= require modal-window
 
-$(document).ready(function() {
+$(function() {
   var menuToggle = $('#js-mobile-menu').unbind();
   $('#js-navigation-menu').removeClass('show');
 

--- a/app/assets/javascripts/modal-window.js
+++ b/app/assets/javascripts/modal-window.js
@@ -1,0 +1,187 @@
+/*
+ 
+ ============================================
+ License for Application
+ ============================================
+ 
+ This license is governed by United States copyright law, and with respect to matters
+ of tort, contract, and other causes of action it is governed by North Carolina law,
+ without regard to North Carolina choice of law provisions.  The forum for any dispute
+ resolution shall be in Wake County, North Carolina.
+ 
+ Redistribution and use in source and binary forms, with or without modification, are
+ permitted provided that the following conditions are met:
+ 
+ 1. Redistributions of source code must retain the above copyright notice, this list
+ of conditions and the following disclaimer.
+ 
+ 2. Redistributions in binary form must reproduce the above copyright notice, this
+ list of conditions and the following disclaimer in the documentation and/or other
+ materials provided with the distribution.
+ 
+ 3. The name of the author may not be used to endorse or promote products derived from
+ this software without specific prior written permission.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE AUTHOR "AS IS" AND ANY EXPRESS OR IMPLIED
+ WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE
+ LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ 
+ */
+
+// jQuery formatted selector to search for focusable items
+var focusableElementsString = "a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), iframe, object, embed, *[tabindex], *[contenteditable]";
+
+// store the item that has focus before opening the modal window
+var focusedElementBeforeModal;
+
+$(document).ready(function() {
+    jQuery('#startModal').click(function(e) {
+        showModal($('#modal'));
+    });
+    jQuery('#cancel').click(function(e) {
+        hideModal();
+    });
+    jQuery('#cancelButton').click(function(e) {
+        hideModal();
+    });
+    jQuery('#enter').click(function(e) {
+        enterButtonModal();
+    });
+    jQuery('#modalCloseButton').click(function(e) {
+        hideModal();
+    });
+    jQuery('#modal').keydown(function(event) {
+        trapTabKey($(this), event);
+    })
+    jQuery('#modal').keydown(function(event) {
+        trapEscapeKey($(this), event);
+    })
+
+});
+
+
+function trapSpaceKey(obj, evt, f) {
+    // if space key pressed
+    if (evt.which == 32) {
+        // fire the user passed event
+        f();
+        evt.preventDefault();
+    }
+}
+
+function trapEscapeKey(obj, evt) {
+
+    // if escape pressed
+    if (evt.which == 27) {
+
+        // get list of all children elements in given object
+        var o = obj.find('*');
+
+        // get list of focusable items
+        var cancelElement;
+        cancelElement = o.filter("#cancel")
+
+        // close the modal window
+        cancelElement.click();
+        evt.preventDefault();
+    }
+
+}
+
+function trapTabKey(obj, evt) {
+
+    // if tab or shift-tab pressed
+    if (evt.which == 9) {
+
+        // get list of all children elements in given object
+        var o = obj.find('*');
+
+        // get list of focusable items
+        var focusableItems;
+        focusableItems = o.filter(focusableElementsString).filter(':visible')
+
+        // get currently focused item
+        var focusedItem;
+        focusedItem = jQuery(':focus');
+
+        // get the number of focusable items
+        var numberOfFocusableItems;
+        numberOfFocusableItems = focusableItems.length
+
+        // get the index of the currently focused item
+        var focusedItemIndex;
+        focusedItemIndex = focusableItems.index(focusedItem);
+
+        if (evt.shiftKey) {
+            //back tab
+            // if focused on first item and user preses back-tab, go to the last focusable item
+            if (focusedItemIndex == 0) {
+                focusableItems.get(numberOfFocusableItems - 1).focus();
+                evt.preventDefault();
+            }
+
+        } else {
+            //forward tab
+            // if focused on the last item and user preses tab, go to the first focusable item
+            if (focusedItemIndex == numberOfFocusableItems - 1) {
+                focusableItems.get(0).focus();
+                evt.preventDefault();
+            }
+        }
+    }
+
+}
+
+function setInitialFocusModal(obj) {
+    // get list of all children elements in given object
+    var o = obj.find('*');
+
+    // set focus to first focusable item
+    var focusableItems;
+    focusableItems = o.filter(focusableElementsString).filter(':visible').first().focus();
+
+}
+
+function enterButtonModal() {
+    // BEGIN logic for executing the Enter button action for the modal window
+    alert('form submitted');
+    // END logic for executing the Enter button action for the modal window
+    hideModal();
+}
+
+function showModal(obj) {
+    jQuery('#mainPage').attr('aria-hidden', 'true'); // mark the main page as hidden
+    jQuery('#modalOverlay').css('display', 'block'); // insert an overlay to prevent clicking and make a visual change to indicate the main apge is not available
+    jQuery('#modal').css('display', 'block'); // make the modal window visible
+    jQuery('#modal').attr('aria-hidden', 'false'); // mark the modal window as visible
+
+    // save current focus
+    focusedElementBeforeModal = jQuery(':focus');
+
+    // get list of all children elements in given object
+    var o = obj.find('*');
+
+    // Safari and VoiceOver shim
+    // if VoiceOver in Safari is used, set the initial focus to the modal window itself instead of the first keyboard focusable item. This causes VoiceOver to announce the aria-labelled attributes. Otherwise, Safari and VoiceOver will not announce the labels attached to the modal window.
+
+    // set the focus to the first keyboard focusable item
+    o.filter(focusableElementsString).filter(':visible').first().focus();
+
+
+}
+
+function hideModal() {
+    jQuery('#modalOverlay').css('display', 'none'); // remove the overlay in order to make the main screen available again
+    jQuery('#modal').css('display', 'none'); // hide the modal window
+    jQuery('#modal').attr('aria-hidden', 'true'); // mark the modal window as hidden
+    jQuery('#mainPage').attr('aria-hidden', 'false'); // mark the main page as visible
+
+    // set focus back to element that had it before the modal was opened
+    focusedElementBeforeModal.focus();
+}

--- a/app/assets/stylesheets/partials/_contact-form.scss
+++ b/app/assets/stylesheets/partials/_contact-form.scss
@@ -33,7 +33,11 @@ form#contact-form {
   }
 }
 
-.alert {
+div#contact-alert {
+  display: none;
+}
+
+.alert-box {
   border-radius: 4px;
   font-size: 14px;
   text-align: center;
@@ -46,4 +50,10 @@ form#contact-form {
   background-color: #EDF6EF;
   border: 1px solid #86C779;
   color: #008C46;
+}
+
+.error {
+  color: #D8000C;
+  background-color: #FFBABA;
+  border: 1px solid #D8000C;
 }

--- a/app/assets/stylesheets/partials/_contact-form.scss
+++ b/app/assets/stylesheets/partials/_contact-form.scss
@@ -8,7 +8,8 @@ form#contact-form {
     margin-bottom: 8px;
   }
 
-  textarea, input[type="text"] {
+  textarea, 
+  input[type="text"] {
     font-size: 13px;
     margin-bottom: 8px;
     width: 100%;
@@ -40,9 +41,9 @@ div#contact-alert {
 .alert-box {
   border-radius: 4px;
   font-size: 14px;
-  text-align: center;
-  padding: 14px 0;
   margin-top: 15px;
+  padding: 14px 0;
+  text-align: center;
   width: 100%;
 }
 

--- a/app/assets/stylesheets/partials/_contact-form.scss
+++ b/app/assets/stylesheets/partials/_contact-form.scss
@@ -1,0 +1,49 @@
+form#contact-form {
+  width: 100%;
+
+  label {
+    color: #666;
+    font-size: 15px;
+    font-weight: bold;
+    margin-bottom: 8px;
+  }
+
+  textarea, input[type="text"] {
+    font-size: 13px;
+    margin-bottom: 8px;
+    width: 100%;
+  }
+
+  textarea {
+    height: 100px;
+  }
+
+  input[type="submit"] {
+    background-color: #0069A0;
+    border-radius: 5px;
+    cursor: pointer;
+    display: block;
+    font-size: 13px;
+    margin: 0 auto;
+    width: 140px;
+  }
+
+  hr {
+    margin: 15px 0;
+  }
+}
+
+.alert {
+  border-radius: 4px;
+  font-size: 14px;
+  text-align: center;
+  padding: 14px 0;
+  margin-top: 15px;
+  width: 100%;
+}
+
+.success {
+  background-color: #EDF6EF;
+  border: 1px solid #86C779;
+  color: #008C46;
+}

--- a/app/assets/stylesheets/partials/_modal.scss
+++ b/app/assets/stylesheets/partials/_modal.scss
@@ -1,48 +1,84 @@
 #modalOverlay {
-  width: 100%;
-  height: 100%;
-  z-index: 9999;
   background-color: white;
-  opacity: 0.5;
-  position:fixed;
-  top: 0;
+  display: none; 
+  height: 100%;
   left: 0;
-  display: none;
   margin: 0;
+  opacity: 0.7;
   padding: 0;
+  position: fixed;
+  top: 0;
+  width: 100%;
+  z-index: 9999;
 }
 
 #modal {
-  width:50%;
-  margin-left:auto;
-  margin-right:auto;
-  padding: 5px;
-  background-color:#fff;
-  z-index: 99999; /* places the modal dialog on top of everything else */
-  position:fixed;
-  top:25%;
-  left:25%;
-  display:none;
-}
-#modal h1 {
-  text-align: center;
-}
-
-.modalCloseButton {
-  float: right;
+  background-color: white;
+  border: 2px solid #C9D4D9;
+  border-radius: 6px;
+  display: none;
+  margin-left: auto;
+  margin-right: auto;
+  padding: 20px;
   position: absolute;
-  top: 10px;
-  left: 92%;
-  height: 25px;
-}
-.modalCloseButton img {
-  border: 0;
+  top: 40px;
+  left: 25%;
+  width: 50%;
+  z-index: 99999;
+
+  @media (max-width: 767px) {
+    left: 15%;
+    width: 70%;
+  }
+
+  @media (max-width: 767px) {
+    left: 10%;
+    width: 80%;
+  }
+
+  h3 {
+    font-size: 15px;
+    font-weight: normal;
+    padding-bottom: 15px;
+  }
+
+  hr {
+    border: 1px solid #EEF2F4;
+  }
+
+  #modalCloseButton {
+    color: #0069A0;
+    cursor: pointer;
+    font-size: 11px;
+    line-height: 1.1;
+    position: absolute;
+    right: 20px;
+    text-align: right;
+    top: 20px;
+    width: 80px;
+    
+    span {
+      color: #9A9A9A;
+      display: block;
+
+      &#cancel {
+
+        background-color: #0069A0;
+        border-radius: 3px;
+        color: white;
+        float: right;
+        font-size: 14px;
+        margin-left: 5px;
+        padding: 4px 10px;
+      }
+    }
+  }
 }
 
 .screen-reader-offscreen {
-  position: absolute;
-  left: -999px;
-  width: 1px;
   height: 1px;
+  left: -999px;
+  position: absolute;
   top: auto;
+  width: 1px;
 }

--- a/app/assets/stylesheets/partials/_modal.scss
+++ b/app/assets/stylesheets/partials/_modal.scss
@@ -1,5 +1,5 @@
 #modalOverlay {
-  background-color: white;
+  background-color: #ffffff;
   display: none; 
   height: 100%;
   left: 0;
@@ -13,16 +13,16 @@
 }
 
 #modal {
-  background-color: white;
-  border: 2px solid #C9D4D9;
+  background-color: #ffffff;
+  border: 2px solid #d9d4d9;
   border-radius: 6px;
   display: none;
+  left: 25%;
   margin-left: auto;
   margin-right: auto;
   padding: 20px;
   position: absolute;
   top: 40px;
-  left: 25%;
   width: 50%;
   z-index: 99999;
 
@@ -43,34 +43,35 @@
   }
 
   hr {
-    border: 1px solid #EEF2F4;
+    border: 1px solid #eef2f4;
   }
 
-  #modalCloseButton {
-    color: #0069A0;
-    cursor: pointer;
-    font-size: 11px;
-    line-height: 1.1;
-    position: absolute;
-    right: 20px;
-    text-align: right;
-    top: 20px;
-    width: 80px;
-    
-    span {
-      color: #9A9A9A;
-      display: block;
+}
 
-      &#cancel {
+#modalCloseButton {
+  color: #0069a0;
+  cursor: pointer;
+  font-size: 11px;
+  line-height: 1.1;
+  position: absolute;
+  right: 20px;
+  text-align: right;
+  top: 20px;
+  width: 80px;
+  
+  span {
+    color: #9a9a9a;
+    display: block;
 
-        background-color: #0069A0;
-        border-radius: 3px;
-        color: white;
-        float: right;
-        font-size: 14px;
-        margin-left: 5px;
-        padding: 4px 10px;
-      }
+    &#cancel {
+
+      background-color: #0069a0;
+      border-radius: 3px;
+      color: #fffff;
+      float: right;
+      font-size: 14px;
+      margin-left: 5px;
+      padding: 4px 10px;
     }
   }
 }

--- a/app/assets/stylesheets/partials/_modal.scss
+++ b/app/assets/stylesheets/partials/_modal.scss
@@ -1,0 +1,48 @@
+#modalOverlay {
+  width: 100%;
+  height: 100%;
+  z-index: 9999;
+  background-color: white;
+  opacity: 0.5;
+  position:fixed;
+  top: 0;
+  left: 0;
+  display: none;
+  margin: 0;
+  padding: 0;
+}
+
+#modal {
+  width:50%;
+  margin-left:auto;
+  margin-right:auto;
+  padding: 5px;
+  background-color:#fff;
+  z-index: 99999; /* places the modal dialog on top of everything else */
+  position:fixed;
+  top:25%;
+  left:25%;
+  display:none;
+}
+#modal h1 {
+  text-align: center;
+}
+
+.modalCloseButton {
+  float: right;
+  position: absolute;
+  top: 10px;
+  left: 92%;
+  height: 25px;
+}
+.modalCloseButton img {
+  border: 0;
+}
+
+.screen-reader-offscreen {
+  position: absolute;
+  left: -999px;
+  width: 1px;
+  height: 1px;
+  top: auto;
+}

--- a/app/assets/stylesheets/partials/_navigation.scss
+++ b/app/assets/stylesheets/partials/_navigation.scss
@@ -32,8 +32,6 @@ header.navigation {
   background-color: $navigation-background;
   border-bottom: 1px solid darken($navigation-background, 10);
   min-height: $navigation-height;
-  width: 100%;
-  z-index: 999;
 
   .navigation-wrapper {
     @include clearfix;

--- a/app/assets/stylesheets/redesign.css.scss
+++ b/app/assets/stylesheets/redesign.css.scss
@@ -24,3 +24,4 @@
 @import "partials/forms";
 @import "partials/homepage";
 @import "partials/permissions";
+@import "partials/modal";

--- a/app/assets/stylesheets/redesign.css.scss
+++ b/app/assets/stylesheets/redesign.css.scss
@@ -25,3 +25,4 @@
 @import "partials/homepage";
 @import "partials/permissions";
 @import "partials/modal";
+@import "partials/contact-form";

--- a/app/views/layouts/redesign.html.erb
+++ b/app/views/layouts/redesign.html.erb
@@ -26,10 +26,18 @@
     <div id="modal" aria-hidden="true" aria-labelledby="modalTitle" aria-describedby="modalDescription" role="dialog">
       <div id="modalDescription" class="screen-reader-offscreen">Beginning of a dialog window for the contact form. It begins with a heading 3 called &quot;Have a question? Let us know!&quot;. Escape will cancel and close the window.</div>
       <h3 id="modalTitle">Have a question? Let us know!</h3>
+      <div id="modalCloseButton" class="modalCloseButton" title="Close registration form">
+        <span id="cancel">X</span>
+        Close 
+        <span>or Esc Key</span>
+      </div>
+
+      <hr />
+      
       <%= form_for :contact_us, url: contact_us_path, html: { id: 'contact-form', role: "form" } do |f| %>
         <div class="form-group">
           <%= f.label 'Message:' %>
-          <%= f.text_area :message, rows: 8, placeholder: 'How can we help you?' %>
+          <%= f.text_area :message, placeholder: 'How can we help you?' %>
         </div>
         <div class="form-group">
           <%= f.label 'Your name:' %>
@@ -39,12 +47,14 @@
           <%= f.label 'Your email:' %>
           <%= f.text_field :return_email, placeholder: 'What is your email address?' %>
         </div>
-        <%= f.submit 'Send Us Your Message', 'data-loading-text' => "Sending your message..." %>
+
+        <hr />
+
+        <%= f.submit 'Send Message', 'data-loading-text' => "Sending your message..." %>
       <% end %>
-      <div class="contact-flash hidden">
-        <div class="message"></div>
+      <div class="alert success">
+        <p class="message">Thank you! Your message has been sent.</p>
       </div>
-      <button id="modalCloseButton" class="modalCloseButton" title="Close registration form"><img id="cancel" src="x.png" alt="close the registration form"></button>
     </div>
     
     <div id="modalOverlay" tabindex="-1"></div>

--- a/app/views/layouts/redesign.html.erb
+++ b/app/views/layouts/redesign.html.erb
@@ -34,7 +34,7 @@
 
       <hr />
       
-      <%= form_for :contact_us, url: contact_us_path, html: { id: 'contact-form', role: "form" } do |f| %>
+      <%= form_for :contact_us, remote: true, url: contact_us_path(format: :json), html: { id: 'contact-form', role: "form" } do |f| %>
         <div class="form-group">
           <%= f.label 'Message:' %>
           <%= f.text_area :message, placeholder: 'How can we help you?' %>
@@ -52,8 +52,8 @@
 
         <%= f.submit 'Send Message', 'data-loading-text' => "Sending your message..." %>
       <% end %>
-      <div class="alert success">
-        <p class="message">Thank you! Your message has been sent.</p>
+      <div id="contact-alert" class="alert-box error">
+        <p class="message">An error has occurred. Please try again.</p>
       </div>
     </div>
     

--- a/app/views/layouts/redesign.html.erb
+++ b/app/views/layouts/redesign.html.erb
@@ -22,10 +22,37 @@
   <body>
 
     <%= yield %>
+
+    <div id="modal" aria-hidden="true" aria-labelledby="modalTitle" aria-describedby="modalDescription" role="dialog">
+      <div id="modalDescription" class="screen-reader-offscreen">Beginning of a dialog window for the contact form. It begins with a heading 3 called &quot;Have a question? Let us know!&quot;. Escape will cancel and close the window.</div>
+      <h3 id="modalTitle">Have a question? Let us know!</h3>
+      <%= form_for :contact_us, url: contact_us_path, html: { id: 'contact-form', role: "form" } do |f| %>
+        <div class="form-group">
+          <%= f.label 'Message:' %>
+          <%= f.text_area :message, rows: 8, placeholder: 'How can we help you?' %>
+        </div>
+        <div class="form-group">
+          <%= f.label 'Your name:' %>
+          <%= f.text_field :from, placeholder: 'What is your name?' %>
+        </div>
+        <div class="form-group">
+          <%= f.label 'Your email:' %>
+          <%= f.text_field :return_email, placeholder: 'What is your email address?' %>
+        </div>
+        <%= f.submit 'Send Us Your Message', 'data-loading-text' => "Sending your message..." %>
+      <% end %>
+      <div class="contact-flash hidden">
+        <div class="message"></div>
+      </div>
+      <button id="modalCloseButton" class="modalCloseButton" title="Close registration form"><img id="cancel" src="x.png" alt="close the registration form"></button>
+    </div>
+    
+    <div id="modalOverlay" tabindex="-1"></div>
     
     <!-- Include all compiled plugins (below), or include individual files as needed -->
     <%= javascript_include_tag "application" %>
 
     <%= render 'layouts/analytics' %>
+
   </body>
 </html>

--- a/app/views/marketing/_contact.html.erb
+++ b/app/views/marketing/_contact.html.erb
@@ -10,7 +10,7 @@
              <a href="#" data-dismiss="alert" class="close">×</a>
              <div class="message"></div>
           </div>
-          <%= form_for :contact_us, url: contact_us_path, html: { id: 'contact-form', role: "form" } do |f| %>
+          <%= form_for :contact_us, url: contact_us_path(format: :json), html: { id: 'contact-form', role: "form" } do |f| %>
             <div class="form-group">
               <%= f.label 'Message:' %>
               <%= f.text_area :message, class: 'form-control', rows: 8, placeholder: 'How can we help you?' %>

--- a/app/views/redesign/_navigation.html.erb
+++ b/app/views/redesign/_navigation.html.erb
@@ -16,7 +16,7 @@
           <%= link_to 'Use MyUSA', '/developer' %>
         </li>
         <li class="nav-link">
-          <%= link_to 'Contact Us', '/#contact' %>
+          <%= link_to 'Contact Us', 'javascript:void(0)', :id => 'startModal' %>
         </li>
         <li class="nav-link">
           <%= link_to '#' do %>

--- a/spec/features/home_page_spec.rb
+++ b/spec/features/home_page_spec.rb
@@ -30,15 +30,18 @@ describe 'Home Page' do
     expect(current_email).to have_content(email)
   end
 
-  context 'without javascript' do
-    it_behaves_like 'user contact form' do
-      let(:display_message) { @home_page.contact_flash_no_js }
-    end
-  end
+  # TODO: Commenting these tests for now until we have a more
+  # solidified version of the app to create solid integration tests.
 
-  context 'with javascript', js: true do
-    it_behaves_like 'user contact form' do
-      let(:message_area) { @home_page.contact_form.message }
-    end
-  end
+  # context 'without javascript' do
+  #   it_behaves_like 'user contact form' do
+  #     let(:display_message) { @home_page.contact_flash_no_js }
+  #   end
+  # end
+
+  # context 'with javascript', js: true do
+  #   it_behaves_like 'user contact form' do
+  #     let(:message_area) { @home_page.contact_form.message }
+  #   end
+  # end
 end

--- a/spec/features/home_page_spec.rb
+++ b/spec/features/home_page_spec.rb
@@ -30,18 +30,22 @@ describe 'Home Page' do
     expect(current_email).to have_content(email)
   end
 
-  # TODO: Commenting these tests for now until we have a more
+  # TODO: Marking these tests pending until we have a more
   # solidified version of the app to create solid integration tests.
 
-  # context 'without javascript' do
-  #   it_behaves_like 'user contact form' do
-  #     let(:display_message) { @home_page.contact_flash_no_js }
-  #   end
-  # end
+  context 'without javascript' do
+    pending "waiting on frontend refactor" do
+      it_behaves_like 'user contact form' do
+        let(:display_message) { @home_page.contact_flash_no_js }
+      end
+    end
+  end
 
-  # context 'with javascript', js: true do
-  #   it_behaves_like 'user contact form' do
-  #     let(:message_area) { @home_page.contact_form.message }
-  #   end
-  # end
+  context 'with javascript', js: true do
+    pending "waiting on frontend refactor" do
+      it_behaves_like 'user contact form' do
+        let(:message_area) { @home_page.contact_form.message }
+      end
+    end
+  end
 end


### PR DESCRIPTION
This pull request is an updated version of the contact us form, based off of the updated navigation layout. In the old design, the contact us form was integrated into the page directly. This version creates a modal where the contact us lives and can be accessible on every page through the site. Here are some notes to take into consideration while reviewing:

- When reviewing the pull request, go to `localhost:3000/redesign` and click on `Contact Us` in the main navigation. 
-  While this is not best practice, I spoke with the dev team and we decided to move forward with commenting out the two failing homepage tests for now. The application is going through some major reconstruction at the moment and we need to re-think we way we re-do our integration tests overall //cc @yozlet @harrisj 

Here is a short clip to see the interactions of the working local version of the form:

![tbw8l7n7ju](https://cloud.githubusercontent.com/assets/955558/8974368/0285d596-363f-11e5-92d4-d1d037d0560a.gif)

Fixes #728 