### PR TITLE
Disabling SCSS linting from Hound CI

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,2 +1,5 @@
 ruby:
   config_file: .rubocop.yml
+
+scss:
+  enabled: false


### PR DESCRIPTION
The SCSS linting that Hound provides is not entirely inline with the 18F frontend CSS coding standards. Disabling this for now and am in favor of using something like @jeremiak post css style linter instead >> https://github.com/jeremiak/postcss-style-linter/

See also https://github.com/18F/frontend/issues/19