### PR TITLE
Valid URLs for post-logout redirection were being rejected

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,10 +12,11 @@ class ApplicationController < ActionController::Base
 
   private
 
+  # Considering this is followed by a test that the URL matches registered domain,
+  # I decided to make this simpler since prior version was rejecting valid URLs
   def valid_url?(uri)
-    !!((uri =~ URI.regexp(%w(http https))) &&
-      URI.parse(uri).host =~
-        /^(localhost|(([0-9]{1,3}\.){3}[0-9]{1,3})|([a-z0-9]+\.)+[a-z]{2,5})$/i)
+    parsed = URI.parse(uri)
+    return (parsed.scheme == 'http' || parsed.scheme == 'https')
   rescue URI::InvalidURIError
     false
   end


### PR DESCRIPTION
Benefits.gov was seeing an error where post-logout redirects to origin-staging.benefits.gov were being ignored because they were erroneously being flagged by a method called `valid_url?` (side note: Nothing makes me more annoyed than a method relying on a complicated regexp that has no tests).

Fixes #747