### PR TITLE
include possible case of a non-public app on the authentication error page

### DIFF
--- a/config/locales/doorkeeper.en.yml
+++ b/config/locales/doorkeeper.en.yml
@@ -46,7 +46,7 @@ en:
         unsupported_response_type: 'The authorization server does not support this response type.'
 
         # Access token errors
-        invalid_client: 'Client authentication failed due to unknown client, no client authentication included, or unsupported authentication method.'
+        invalid_client: 'Client authentication failed due to unknown client, no client authentication included, the application not being public, or unsupported authentication method.'
         invalid_grant: 'The provided authorization grant is invalid, expired, revoked, does not match the redirection URI used in the authorization request, or was issued to another client.'
         unsupported_grant_type: 'The authorization grant type is not supported by the authorization server.'
 

--- a/spec/features/doorkeeper/oauth_spec.rb
+++ b/spec/features/doorkeeper/oauth_spec.rb
@@ -306,9 +306,7 @@ describe 'OAuth' do
             expect(@auth_page).to be_displayed
             expect(@auth_page).to have_error_message
             expect(@auth_page.error_message.text).to(
-              include('Client authentication failed due to unknown client, ' \
-                      'no client authentication included, or unsupported ' \
-                      'authentication method.'))
+              include('Client authentication failed due to unknown client'))
           end
         end
       end


### PR DESCRIPTION
@ctro @stroupaloop and I all ran into [this problem](https://18f.slack.com/archives/myusa/p1461078357000018) in the past two days, of missing the "make your application public" step. If MyUSA resurrects or this flow is used in the Identity project, it should probably be revisited to avoid developers forgetting / not realizing the app isn't public, but hopefully this slightly better error message will be a useful hint.
